### PR TITLE
Update neighbor particle stuff to use the new C++-ready style.

### DIFF
--- a/exec/immersedIons/inputs_regression_cond
+++ b/exec/immersedIons/inputs_regression_cond
@@ -97,7 +97,7 @@
   seed = 1
   k_B = 1.38064852e-16
   T_init(1) = 295.00
-  variance_coef_mom = 1
+  variance_coef_mom = 0
    
 
   ! Boundary conditions

--- a/exec/immersedIons/inputs_regression_cond
+++ b/exec/immersedIons/inputs_regression_cond
@@ -97,7 +97,7 @@
   seed = 1
   k_B = 1.38064852e-16
   T_init(1) = 295.00
-  variance_coef_mom = 0
+  variance_coef_mom = 1
    
 
   ! Boundary conditions

--- a/exec/immersedIons/main_driver.cpp
+++ b/exec/immersedIons/main_driver.cpp
@@ -919,6 +919,7 @@ void main_driver(const char* argv)
                 particles.MeanSqrCalc(0, 0);
             }
 
+			particles.clearNeighbors();
             particles.Redistribute();
             particles.ReBin();
             Print() << "Finish move.\n";

--- a/exec/immersed_boundary/channel_dumbbell/advance.cpp
+++ b/exec/immersed_boundary/channel_dumbbell/advance.cpp
@@ -274,7 +274,7 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         // Get marker data (local to current thread)
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & markers = ib_mc.GetParticles(ib_lev).at(index).GetArrayOfStructs();
-        long np = markers.size();
+        long np = ib_mc.GetParticles(ib_lev).at(index).numParticles();
 
         for (MarkerListIndex m_index(0, 0); m_index.first<np; ++m_index.first) {
 
@@ -439,7 +439,7 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         // Get marker data (local to current thread)
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & markers = ib_mc.GetParticles(ib_lev).at(index).GetArrayOfStructs();
-        long np = markers.size();
+        long np = ib_mc.GetParticles(ib_lev).at(index).numParticles();
 
         for (MarkerListIndex m_index(0, 0); m_index.first<np; ++m_index.first) {
 

--- a/exec/immersed_boundary/channel_multiblob/advance.cpp
+++ b/exec/immersed_boundary/channel_multiblob/advance.cpp
@@ -270,7 +270,7 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
     //     // Get marker data (local to current thread)
     //     TileIndex index(pti.index(), pti.LocalTileIndex());
     //     AoS & markers = ib_mbc.GetParticles(ib_lev).at(index).GetArrayOfStructs();
-    //     long np = markers.size();
+    //     long np = ib_mbc.GetParticles(ib_lev).at(index).numParticles();
 
     //     // m_index.second is used to keep track of the neighbor list
     //     for (MarkerListIndex m_index(0, 0); m_index.first<np; ++m_index.first) {
@@ -424,7 +424,7 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         IBMultiBlobContainer::TileIndex index(pti.index(), pti.LocalTileIndex());
         IBMultiBlobContainer::AoS & markers =
             ib_mbc.GetParticles(ib_lev).at(index).GetArrayOfStructs();
-        long np = markers.size();
+        long np = ib_mbc.GetParticles(ib_lev).at(index).numParticles();
 
         for (int i=0; i<np; ++i) {
 
@@ -448,7 +448,7 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         IBMultiBlobContainer::TileIndex index(pti.index(), pti.LocalTileIndex());
         IBMultiBlobContainer::AoS & markers =
             ib_mbc.GetParticles(ib_lev).at(index).GetArrayOfStructs();
-        long np = markers.size();
+        long np = ib_mbc.GetParticles(ib_lev).at(index).numParticles();
 
         for (int i=0; i<np; ++i) {
 
@@ -475,7 +475,7 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
     //     // Get marker data (local to current thread)
     //     TileIndex index(pti.index(), pti.LocalTileIndex());
     //     AoS & markers = ib_mbc.GetParticles(ib_lev).at(index).GetArrayOfStructs();
-    //     long np = markers.size();
+    //     long np = ib_mbc.GetParticles(ib_lev).at(index).numParticles();
 
     //     // m_index.second is used to keep track of the neighbor list
     //     for (MarkerListIndex m_index(0, 0); m_index.first<np; ++m_index.first) {

--- a/exec/immersed_boundary/channel_multiblob/main_driver.cpp
+++ b/exec/immersed_boundary/channel_multiblob/main_driver.cpp
@@ -389,7 +389,7 @@ void main_driver(const char * argv) {
         IBMultiBlobContainer::TileIndex index(pti.index(), pti.LocalTileIndex());
         IBMultiBlobContainer::AoS & markers =
             ib_mbc.GetParticles(0).at(index).GetArrayOfStructs();
-        long np = markers.size();
+        long np = ib_mbc.GetParticles(0).at(index).numParticles();
 
         for (int i=0; i<np; ++i) {
 

--- a/exec/immersed_boundary/flagellum/ib_md.cpp
+++ b/exec/immersed_boundary/flagellum/ib_md.cpp
@@ -22,7 +22,7 @@ void constrain_ibm_marker(IBMarkerContainer & ib_mc, int ib_lev, int component) 
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & markers = ib_mc.GetParticles(ib_lev).at(index).GetArrayOfStructs();
 
-        long np = markers.size();
+        long np = ib_mc.GetParticles(ib_lev).at(index).numParticles();
 
         for (int i = 0; i < np; ++i) {
 
@@ -47,7 +47,7 @@ void anchor_first_marker(IBMarkerContainer & ib_mc, int ib_lev, int component) {
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & markers = ib_mc.GetParticles(ib_lev).at(index).GetArrayOfStructs();
 
-        long np = markers.size();
+        long np = ib_mc.GetParticles(ib_lev).at(index).numParticles();
 
         for (int i = 0; i < np; ++i) {
 
@@ -119,7 +119,7 @@ void update_ibm_marker(const RealVect & driv_u, Real driv_amp, Real time,
         // Get marker data (local to current thread)
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & markers = ib_mc.GetParticles(ib_lev).at(index).GetArrayOfStructs();
-        long np = markers.size();
+        long np = ib_mc.GetParticles(ib_lev).at(index).numParticles();
 
         for (MarkerListIndex m_index(0, 0); m_index.first<np; ++m_index.first) {
 

--- a/src_immersed-boundary/IBMarkerContainer.H
+++ b/src_immersed-boundary/IBMarkerContainer.H
@@ -126,7 +126,7 @@ public:
 
 
     // Get number of particles
-    int NumberOfMarkers(IBMarIter & pti){ return pti.GetArrayOfStructs().size();};
+    int NumberOfMarkers(IBMarIter & pti){ return pti.GetArrayOfStructs().numParticles();};
 
 
 

--- a/src_immersed-boundary/IBMarkerContainer.cpp
+++ b/src_immersed-boundary/IBMarkerContainer.cpp
@@ -166,7 +166,7 @@ void IBMarkerContainer::InitList(int lev,
         // Get neighbor marker data (from neighboring threads)
         ParticleVector & nbhd_data = GetNeighbors(lev, pti.index(), pti.LocalTileIndex());
 
-        long np = markers.size();
+        long np = pti.numParticles();
         long nn = nbhd_data.size();
 
         // Sweep over particles, check N^2 candidates for previous list member
@@ -376,7 +376,7 @@ int IBMarkerContainer::ConnectedMarkers(
     // Get marker data
     AoS & particles = GetParticles(lev).at(tile).GetArrayOfStructs();
     ParticleType & part = particles[part_index.first];
-    long np = particles.size();
+    long np = GetParticles(lev).at(tile).numParticles();
 
     // Get neighbor marker data (from neighboring threads)
     ParticleVector & nbhd_data = GetNeighbors(lev, tile.first, tile.second);
@@ -457,7 +457,7 @@ void IBMarkerContainer::LocalIBMarkerInfo(Vector<IBM_info> & info,
 
 
     auto & particle_data = GetParticles(lev).at(index);
-    long np = particle_data.size();
+    long np = particle_data.numParticles();
 
     // Iterate over local particle data
     const AoS & particles = particle_data.GetArrayOfStructs();

--- a/src_immersed-boundary/IBMarkerContainerBase.H
+++ b/src_immersed-boundary/IBMarkerContainerBase.H
@@ -73,7 +73,7 @@ public:
 
     // Get number of particles
     int NumberOfMarkers(IBMarIterBase<StructReal::count, StructInt::count> & pti){
-        return pti.GetArrayOfStructs().size();
+        return pti.GetArrayOfStructs().numParticles();
     };
 
 

--- a/src_immersed-boundary/IBMarkerContainerBaseI.H
+++ b/src_immersed-boundary/IBMarkerContainerBaseI.H
@@ -67,7 +67,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::MoveMarkers(int lev, Real dt)
         TileIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         for (int i = 0; i < np; ++ i) {
             ParticleType & part = particles[i];
@@ -96,7 +96,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::RFD(
         TileIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         for (int i=0; i<np; ++i) {
             ParticleType & part = particles[i];
@@ -128,7 +128,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::RFD(
         TileIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         for (int i=0; i<np; ++i) {
             ParticleType & part = particles[i];
@@ -156,7 +156,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::RFD(
         TileIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         for (int i=0; i<np; ++i) {
             ParticleType & part = particles[i];
@@ -182,7 +182,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::MovePredictor(int lev, Real d
         TileIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         for (int i = 0; i < np; ++ i) {
             ParticleType & part = particles[i];
@@ -213,7 +213,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::PullDown(
 
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         int id;
 
@@ -275,7 +275,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::PullDownInt(
 
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         int id;
         if (element >= 0) {
@@ -338,7 +338,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::PushUpAdd(
 
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         int id;
         if(element >= 0) {
@@ -371,7 +371,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::ResetMarkers(int lev) {
 
         TileIndex index(pti.index(), pti.LocalTileIndex());
         auto & particle_data = this->GetParticles(lev).at(index);
-        long np = particle_data.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         AoS & particles = particle_data.GetArrayOfStructs();
         for (int i = 0; i < np; ++i) {
@@ -394,7 +394,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::ResetPredictor(int lev) {
 
         TileIndex index(pti.index(), pti.LocalTileIndex());
         auto & particle_data = this->GetParticles(lev).at(index);
-        long np = particle_data.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         AoS & particles = particle_data.GetArrayOfStructs();
         for (int i = 0; i < np; ++i) {
@@ -547,7 +547,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::SpreadMarkers(
 
         //_______________________________________________________________________
         // Fill vector of marker positions and forces (for current level)
-        long np = particle_data.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         Vector<RealVect> marker_positions(np), marker_forces(np);
 
@@ -634,7 +634,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::SpreadPredictor(
 
         //_______________________________________________________________________
         // Fill vector of marker positions and forces (for current level)
-        long np = particle_data.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         Vector<RealVect> marker_positions(np), marker_forces(np);
 
@@ -787,7 +787,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::InterpolateMarkers(
 
         //_______________________________________________________________________
         // Fill vector of marker positions and forces (for current level)
-        long np = particle_data.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         Vector<RealVect> marker_positions(np), marker_forces(np);
 
@@ -867,7 +867,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::InterpolatePredictor(
 
         //_______________________________________________________________________
         // Fill vector of marker positions and forces (for current level)
-        long np = particle_data.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         Vector<RealVect> marker_positions(np), marker_forces(np);
 
@@ -946,7 +946,7 @@ void IBMarkerContainerBase<StructReal, StructInt>::PrintMarkerData(int lev) cons
         int ng = this->neighbors[lev].at(index).size();
 
         auto & particle_data = this->GetParticles(lev).at(index);
-        long np = particle_data.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         local_count += np;
 

--- a/src_immersed-boundary/IBMultiBlobContainer.H
+++ b/src_immersed-boundary/IBMultiBlobContainer.H
@@ -236,7 +236,7 @@ public:
 
     // Get number of particles
     int NumberOfParticles(IBMBIter & pti){
-        return pti.GetArrayOfStructs().size();
+        return pti.GetArrayOfStructs().numParticles();
     };
 
 

--- a/src_immersed-boundary/IBMultiBlobContainer.cpp
+++ b/src_immersed-boundary/IBMultiBlobContainer.cpp
@@ -166,7 +166,7 @@ void BlobContainer::MovePredictor(int lev, Real dt) {
         TileIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         for (int i=0; i<np; ++i) {
             ParticleType & part = particles[i];
@@ -205,7 +205,7 @@ void BlobContainer::MoveMarkers(int lev, Real dt) {
         TileIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         for (int i=0; i<np; ++i) {
             ParticleType & part = particles[i];
@@ -227,7 +227,7 @@ void BlobContainer::PredictorForces(int lev, Real k) {
         // Get marker data (local to current thread)
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & markers = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = markers.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -252,7 +252,7 @@ void BlobContainer::PredictorForces(int lev) {
         // Get marker data (local to current thread)
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & markers = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = markers.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -277,7 +277,7 @@ void BlobContainer::MarkerForces(int lev, Real k) {
         // Get marker data (local to current thread)
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & markers = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = markers.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -302,7 +302,7 @@ void BlobContainer::MarkerForces(int lev) {
         // Get marker data (local to current thread)
         TileIndex index(pti.index(), pti.LocalTileIndex());
         AoS & markers = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = markers.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -470,7 +470,7 @@ void IBMultiBlobContainer::FillMarkerPositions(int lev) {
         TileIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = GetParticles(lev).at(index).numParticles();
 
         for (int i = 0; i < np; ++i) {
             ParticleType & part = particles[i];
@@ -564,7 +564,7 @@ void IBMultiBlobContainer::ResetDrag(int lev) {
 
         TileIndex index(pti.index(), pti.LocalTileIndex());
         auto & particle_data = this->GetParticles(lev).at(index);
-        long np = particle_data.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         AoS & particles = particle_data.GetArrayOfStructs();
         for (int i = 0; i < np; ++i) {
@@ -637,7 +637,7 @@ void IBMultiBlobContainer::MoveMarkers(int lev, Real dt) {
 
         BlobContainer::AoS & marker_data =
             markers.GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = marker_data.size();
+        long np = markers.GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -677,7 +677,7 @@ void IBMultiBlobContainer::MovePredictor(int lev, Real dt) {
 
         BlobContainer::AoS & marker_data =
             markers.GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = marker_data.size();
+        long np = markers.GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -717,7 +717,7 @@ void IBMultiBlobContainer::PredictorForces(int lev) {
         // Get marker data (local to current thread)
         BlobContainer::AoS & marker_data =
             markers.GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = marker_data.size();
+        long np = markers.GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -750,7 +750,7 @@ void IBMultiBlobContainer::PredictorForces(int lev, Real k) {
         // Get marker data (local to current thread)
         BlobContainer::AoS & marker_data =
             markers.GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = marker_data.size();
+        long np = markers.GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -784,7 +784,7 @@ void IBMultiBlobContainer::MarkerForces(int lev, Real k) {
         // Get marker data (local to current thread)
         BlobContainer::AoS & marker_data =
             markers.GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = marker_data.size();
+        long np = markers.GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -817,7 +817,7 @@ void IBMultiBlobContainer::MarkerForces(int lev) {
         // Get marker data (local to current thread)
         BlobContainer::AoS & marker_data =
             markers.GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = marker_data.size();
+        long np = markers.GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -858,7 +858,7 @@ IBMultiBlobContainer::GetParticleDict(int lev, const TileIndex & index) {
 
 
     auto & particle_data = this->GetParticles(lev).at(index);
-    long np = particle_data.size();
+    long np = this->GetParticles(lev).at(index).numParticles();
 
     AoS & particles = particle_data.GetArrayOfStructs();
     for (int i = 0; i < np; ++i) {
@@ -890,7 +890,7 @@ void IBMultiBlobContainer::AccumulateDrag(int lev) {
         // Get marker data (local to current thread)
         BlobContainer::AoS & marker_data =
             markers.GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = marker_data.size();
+        long np = markers.GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -940,7 +940,7 @@ void IBMultiBlobContainer::MoveBlob(int lev, Real dt) {
         std::map<MarkerIndex, ParticleType *> particle_dict = GetParticleDict(lev, index);
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         for (int i = 0; i < np; ++ i) {
             ParticleType & part = particles[i];
@@ -962,7 +962,7 @@ void IBMultiBlobContainer::MoveBlob(int lev, Real dt) {
 
         BlobContainer::AoS & marker_data =
             markers.GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = marker_data.size();
+        long np = markers.GetParticles(lev).at(index).numParticles();
 
         // m_index.second is used to keep track of the neighbor list
         // currently we don't use the neighbor list, but we might in future
@@ -1026,7 +1026,7 @@ void IBMultiBlobContainer::PrintMarkerData(int lev) const {
         int ng = this->neighbors[lev].at(index).size();
 
         auto & particle_data = this->GetParticles(lev).at(index);
-        long np = particle_data.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         local_count += np;
 

--- a/src_immersed-boundary/IBParticleContainer.H
+++ b/src_immersed-boundary/IBParticleContainer.H
@@ -114,7 +114,7 @@ public:
         ::NeighborParticleContainer;
 
     // Get number of particles
-    int NumberOfParticles(IBParIter & pti){ return pti.GetArrayOfStructs().size();};
+    int NumberOfParticles(IBParIter & pti){ return pti.GetArrayOfStructs().numParticles();};
 
     IBParticleContainer(AmrCore * amr_core, int n_nbhd);
     IBParticleContainer(const Geometry & geom, const DistributionMapping & dmap,

--- a/src_immersed-boundary/IBParticleContainer.cpp
+++ b/src_immersed-boundary/IBParticleContainer.cpp
@@ -262,7 +262,7 @@ void IBParticleContainer::FillMarkerPositions(int lev, int n_marker) {
         PairIndex index(pti.index(), pti.LocalTileIndex());
 
         auto & particle_data = GetParticles(lev)[index];
-        long np = particle_data.size();
+        long np = GetParticles(lev)[index].numParticles();
 
         // Iterate over local particle data
         AoS & particles = particle_data.GetArrayOfStructs();
@@ -1028,7 +1028,7 @@ void IBParticleContainer::InterpolateParticleForces(int lev,
         PairIndex index(pti.index(), pti.LocalTileIndex());
 
         auto & particle_data = GetParticles(lev)[index];
-        long np = particle_data.size();
+        long np = GetParticles(lev)[index].numParticles();
 
         // Iterate over local particle data
         AoS & particles = particle_data.GetArrayOfStructs();
@@ -1181,7 +1181,7 @@ void IBParticleContainer::MoveIBParticles(int lev, Real dt,
 
         PairIndex index(pti.index(), pti.LocalTileIndex());
         auto & particle_data = GetParticles(lev)[index];
-        long np = particle_data.size();
+        long np = GetParticles(lev)[index].numParticles();
 
         AoS & particles = particle_data.GetArrayOfStructs();
         for (int i = 0; i < np; ++i) {
@@ -1236,9 +1236,8 @@ void IBParticleContainer::PrintParticleData(int lev) {
         // Neighbours are stored as raw data (see below)
         int ng = neighbors[lev][index].size();
 
-        //long np = NumberOfParticles(pti);
         auto & particle_data = GetParticles(lev)[index];
-        long np = particle_data.size();
+        long np = GetParticles(lev)[index].numParticles();
 
         local_count += np;
 
@@ -1308,7 +1307,7 @@ void IBParticleContainer::LocalIBParticleInfo(Vector<IBP_info> & info,
 
 
     auto & particle_data = GetParticles(lev).at(index);
-    long np = particle_data.size();
+    long np = GetParticles(lev).at(index).numParticles();
 
     // Iterate over local particle data
     const AoS & particles = particle_data.GetArrayOfStructs();

--- a/src_particles/FhdParticleContainer.cpp
+++ b/src_particles/FhdParticleContainer.cpp
@@ -232,8 +232,8 @@ void FhdParticleContainer::computeForcesNL(const MultiFab& charge, const MultiFa
       
         PairIndex index(pti.index(), pti.LocalTileIndex());
         AoS& particles = pti.GetArrayOfStructs();
-        int Np = particles.size();
-        int Nn = neighbors[lev][index].size();
+        int Np = pti.numParticles();
+        int Nn = pti.numNeighborParticles();
         int size = neighbor_list[lev][index].size();
 
         const Box& tile_box  = pti.tilebox();
@@ -1505,7 +1505,7 @@ FhdParticleContainer::PrintParticles()
         PairIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         for(int i=0; i<np; ++i)
         {
@@ -1535,7 +1535,7 @@ FhdParticleContainer::SetPosition(int rank, int id, Real x, Real y, Real z)
             PairIndex index(pti.index(), pti.LocalTileIndex());
 
             AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-            long np = particles.size();
+            long np = this->GetParticles(lev).at(index).numParticles();
 
             if(id <= np)
             {
@@ -1573,7 +1573,7 @@ FhdParticleContainer::SetVel(int rank, int id, Real x, Real y, Real z)
             PairIndex index(pti.index(), pti.LocalTileIndex());
 
             AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-            long np = particles.size();
+            long np = this->GetParticles(lev).at(index).numParticles();
  
             ParticleType & part = particles[id-1];
 
@@ -1599,7 +1599,7 @@ FhdParticleContainer::MeanSqrCalc(int lev, int reset) {
         TileIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
         nTotal += np;
 
         for (int i=0; i<np; ++i) {
@@ -1686,7 +1686,7 @@ FhdParticleContainer::BuildCorrectionTable(const Real* dx, int setMeasureFinal) 
         TileIndex index(pti.index(), pti.LocalTileIndex());
 
         AoS & particles = this->GetParticles(lev).at(index).GetArrayOfStructs();
-        long np = particles.size();
+        long np = this->GetParticles(lev).at(index).numParticles();
 
         if(setMeasureFinal == 0)
         {

--- a/src_particles/FhdParticleContainer.cpp
+++ b/src_particles/FhdParticleContainer.cpp
@@ -1554,10 +1554,10 @@ FhdParticleContainer::SetPosition(int rank, int id, Real x, Real y, Real z)
            
         }
     }
+    clearNeighbors();
     Redistribute();
     UpdateCellVectors();
     ReBin();
-    clearNeighbors();
     fillNeighbors();
 }
 


### PR DESCRIPTION
These are a few changes that were needed before we can port the particle code in FHDeX to C++ / GPUs. 

I tested this using the deterministic version of the immersedIons test that runs every night. These are diffs I get:

variable name      |      absolute error      |      relative error
------------ | ------------- | --------------
averaged_velx         |             6.938893904e-17      |     4.120906547e-16
averaged_vely         |             9.714451465e-17     |      6.675664696e-16
averaged_velz         |            5.551115123e-17      |     4.944677048e-16
shifted_velx             |          7.632783294e-17       |    4.513945216e-16
shifted_vely             |          1.110223025e-16       |    7.251131321e-16
shifted_velz             |          6.938893904e-17      |     6.108134607e-16
pres                         |      2.216893336e-12         |  1.944270327e-16
divergence              |          2.182787284e-10      |     0.0001398666605
averaged_meanx    |                 5.551115123e-17     |      3.296722395e-16
averaged_meany     |                 4.33680869e-17     |      2.980193869e-16
averaged_meanz      |               5.551115123e-17    |       4.944671197e-16
averaged_varx           |           6.912329942e-23      |     1.827840733e-11
averaged_vary           |           3.407015781e-23      |     2.297527305e-11
averaged_varz            |          5.128136096e-23      |     4.450463551e-11

This branch shouldn't be merged until the corresponding one to AMReX is