### PR TITLE
Set correct BC for isothermal walls

### DIFF
--- a/src_compressible/boundary.cpp
+++ b/src_compressible/boundary.cpp
@@ -839,3 +839,148 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
     }
 }
 
+// set species and total density flux to zero for wall boundary conditions
+void BCWallSpeciesFlux(std::array< MultiFab, AMREX_SPACEDIM >& faceflux, const amrex::Geometry geom)
+{
+    BL_PROFILE_VAR("BCWallSpeciesFlux()",BCWallSpeciesFlux);
+
+    // LO X
+    if (bc_mass_lo[0] == 1) {
+
+        // domain grown nodally based on faceflux[0] nodality (x)
+        const Box& dom_x = amrex::convert(geom.Domain(), faceflux[0].ixType());
+
+        // this is the x-lo domain boundary box (x nodality)
+        // Orientation(dir,Orientation)  -- Orientation can be ::low or ::high
+        const Box& dom_xlo = amrex::bdryNode(dom_x, Orientation(0, Orientation::low));
+
+        for (MFIter mfi(faceflux[0]); mfi.isValid(); ++mfi) {
+            const Box& bx = mfi.fabbox();
+            const Box& b = bx & dom_xlo;
+            Array4<Real> const& flux = (faceflux[0]).array(mfi);
+            if (b.ok()) {
+                amrex::ParallelFor(b, nspecies, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+                {
+                    flux(i,j,k,n+5) = 0.;
+                    if (n==0) flux(i,j,k,n) = 0.;
+                });
+            }
+        }
+    }
+    // HI X
+    if (bc_mass_hi[0] == 1) {
+
+        // domain grown nodally based on faceflux[0] nodality (x)
+        const Box& dom_x = amrex::convert(geom.Domain(), faceflux[0].ixType());
+
+        // this is the x-hi domain boundary box (x nodality)
+        // Orientation(dir,Orientation)  -- Orientation can be ::low or ::high
+        const Box& dom_xhi = amrex::bdryNode(dom_x, Orientation(0, Orientation::high));
+
+        for (MFIter mfi(faceflux[0]); mfi.isValid(); ++mfi) {
+            const Box& bx = mfi.fabbox();
+            const Box& b = bx & dom_xhi;
+            Array4<Real> const& flux = (faceflux[0]).array(mfi);
+            if (b.ok()) {
+                amrex::ParallelFor(b, nspecies, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+                {
+                    flux(i,j,k,n+5) = 0.;
+                    if (n==0) flux(i,j,k,n) = 0.;
+                });
+            }
+        }
+    }
+    // LO Y
+    if (bc_mass_lo[1] == 1) {
+
+        // domain grown nodally based on faceflux[1] nodality (y)
+        const Box& dom_y = amrex::convert(geom.Domain(), faceflux[1].ixType());
+
+        // this is the y-lo domain boundary box (y nodality)
+        // Orientation(dir,Orientation)  -- Orientation can be ::low or ::high
+        const Box& dom_ylo = amrex::bdryNode(dom_y, Orientation(1, Orientation::low));
+
+        for (MFIter mfi(faceflux[1]); mfi.isValid(); ++mfi) {
+            const Box& bx = mfi.fabbox();
+            const Box& b = bx & dom_ylo;
+            Array4<Real> const& flux = (faceflux[1]).array(mfi);
+            if (b.ok()) {
+                amrex::ParallelFor(b, nspecies, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+                {
+                    flux(i,j,k,n+5) = 0.;
+                    if (n==0) flux(i,j,k,n) = 0.;
+                });
+            }
+        }
+    }
+    // HI Y 
+    if (bc_mass_hi[1] == 1) {
+
+        // domain grown nodally based on faceflux[1] nodality (y)
+        const Box& dom_y = amrex::convert(geom.Domain(), faceflux[1].ixType());
+
+        // this is the y-hi domain boundary box (y nodality)
+        // Orientation(dir,Orientation)  -- Orientation can be ::low or ::high
+        const Box& dom_yhi = amrex::bdryNode(dom_y, Orientation(1, Orientation::high));
+
+        for (MFIter mfi(faceflux[1]); mfi.isValid(); ++mfi) {
+            const Box& bx = mfi.fabbox();
+            const Box& b = bx & dom_yhi;
+            Array4<Real> const& flux = (faceflux[1]).array(mfi);
+            if (b.ok()) {
+                amrex::ParallelFor(b, nspecies, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+                {
+                    flux(i,j,k,n+5) = 0.;
+                    if (n==0) flux(i,j,k,n) = 0.;
+                });
+            }
+        }
+    }
+    // LO Z
+    if (bc_mass_lo[2] == 1) {
+
+        // domain grown nodally based on faceflux[2] nodality (z)
+        const Box& dom_z = amrex::convert(geom.Domain(), faceflux[2].ixType());
+
+        // this is the z-lo domain boundary box (z nodality)
+        // Orientation(dir,Orientation)  -- Orientation can be ::low or ::high
+        const Box& dom_zlo = amrex::bdryNode(dom_z, Orientation(2, Orientation::low));
+
+        for (MFIter mfi(faceflux[2]); mfi.isValid(); ++mfi) {
+            const Box& bx = mfi.fabbox();
+            const Box& b = bx & dom_zlo;
+            Array4<Real> const& flux = (faceflux[2]).array(mfi);
+            if (b.ok()) {
+                amrex::ParallelFor(b, nspecies, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+                {
+                    flux(i,j,k,n+5) = 0.;
+                    if (n==0) flux(i,j,k,n) = 0.;
+                });
+            }
+        }
+    }
+    // HI Z
+    if (bc_mass_hi[2] == 1) {
+
+        // domain grown nodally based on faceflux[2] nodality (z)
+        const Box& dom_z = amrex::convert(geom.Domain(), faceflux[2].ixType());
+
+        // this is the z-hi domain boundary box (z nodality)
+        // Orientation(dir,Orientation)  -- Orientation can be ::low or ::high
+        const Box& dom_zhi = amrex::bdryNode(dom_z, Orientation(2, Orientation::high));
+
+        for (MFIter mfi(faceflux[2]); mfi.isValid(); ++mfi) {
+            const Box& bx = mfi.fabbox();
+            const Box& b = bx & dom_zhi;
+            Array4<Real> const& flux = (faceflux[2]).array(mfi);
+            if (b.ok()) {
+                amrex::ParallelFor(b, nspecies, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+                {
+                    flux(i,j,k,n+5) = 0.;
+                    if (n==0) flux(i,j,k,n) = 0.;
+                });
+            }
+        }
+    }
+}
+

--- a/src_compressible/compressible_functions.H
+++ b/src_compressible/compressible_functions.H
@@ -57,6 +57,9 @@ void primitiveToConserved(const MultiFab& prim, MultiFab& cons);
 
 void setBC(MultiFab& prim, MultiFab& cons);
 
+void BCWallSpeciesFlux(std::array< MultiFab, AMREX_SPACEDIM >& flux,
+                       const amrex::Geometry geom);
+
 void evaluateStats(const MultiFab& cons, MultiFab& consMean, MultiFab& consVar,
                    const MultiFab& prim, MultiFab& primMean, MultiFab& primVar,
                    MultiFab& spatialCross, MultiFab& miscStats, Real* miscVals,

--- a/src_compressible/timeStep.cpp
+++ b/src_compressible/timeStep.cpp
@@ -105,6 +105,9 @@ void RK3step(MultiFab& cu, MultiFab& cup, MultiFab& cup2, MultiFab& cup3,
     calculateFlux(cu, prim, eta, zeta, kappa, chi, D, flux, stochFlux, cornx, corny, cornz,
                   visccorn, rancorn, geom, stoch_weights, dt);
 
+    // Set species flux to zero at the walls
+    BCWallSpeciesFlux(flux,geom);
+
     for ( MFIter mfi(cu,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         
         const Box& bx = mfi.tilebox();
@@ -199,6 +202,9 @@ void RK3step(MultiFab& cu, MultiFab& cup, MultiFab& cup2, MultiFab& cup3,
     calculateFlux(cup, prim, eta, zeta, kappa, chi, D, flux, stochFlux, cornx, corny, cornz,
                   visccorn, rancorn, geom, stoch_weights, dt);
 
+    // Set species flux to zero at the walls
+    BCWallSpeciesFlux(flux,geom);
+
     for ( MFIter mfi(cu,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         
         const Box& bx = mfi.tilebox();
@@ -292,6 +298,9 @@ void RK3step(MultiFab& cu, MultiFab& cup, MultiFab& cup2, MultiFab& cup3,
 
     calculateFlux(cup2, prim, eta, zeta, kappa, chi, D, flux, stochFlux, cornx, corny, cornz,
                   visccorn, rancorn, geom, stoch_weights, dt);
+
+    // Set species flux to zero at the walls
+    BCWallSpeciesFlux(flux,geom);
 
     for ( MFIter mfi(cu,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         


### PR DESCRIPTION
Added logic to set species and total mass flux to be zero at the walls for an an isothermal walls. This is required to negate the Soret effects at the walls. 