### PR TITLE
Fix max species

### DIFF
--- a/src_common/common_functions.H
+++ b/src_common/common_functions.H
@@ -1,7 +1,6 @@
 #ifndef _common_functions_H_
 #define _common_functions_H_
 
-#define LOHI 2
 #if (AMREX_SPACEDIM == 2)
 #define NUM_EDGE 1
 #else

--- a/src_common/common_functions.cpp
+++ b/src_common/common_functions.cpp
@@ -61,7 +61,7 @@ void InitializeCommonNamespace() {
     max_grid_projection.resize(AMREX_SPACEDIM-1);
 
     density_weights.resize(MAX_SPECIES);
-    shift_cc_to_boundary.resize(AMREX_SPACEDIM*LOHI);
+    shift_cc_to_boundary.resize(AMREX_SPACEDIM*2);
 
     mass.resize(MAX_SPECIES);
     nfrac.resize(MAX_SPECIES);
@@ -143,6 +143,10 @@ void InitializeCommonNamespace() {
     plot_base_name = temp_plot_base_name;
     chk_base_name = temp_chk_base_name;
 
+    if (nspecies > MAX_SPECIES) {
+        Abort("InitializeCommonNamespace: nspecies > MAX_SPECIES");
+    }
+    
     ParmParse pp;
 
     // read in from command line

--- a/src_common/common_namespace.H
+++ b/src_common/common_namespace.H
@@ -1,6 +1,9 @@
 namespace common {
 
+//////////////
+// DO NOT CHANGE THIS VALUE WITHOUT ALSO CHANGING common_namelist.F90
 #define MAX_SPECIES 8
+//////////////
     
     // misc global variables
     extern amrex::IntVect nodal_flag;

--- a/src_common/common_namespace.H
+++ b/src_common/common_namespace.H
@@ -2,7 +2,8 @@ namespace common {
 
 //////////////
 // DO NOT CHANGE THIS VALUE WITHOUT ALSO CHANGING common_namelist.F90
-#define MAX_SPECIES 4
+#define MAX_SPECIES 8
+#define MAX_ELEMENT 28 // needs to be MAX_SPECIES*(MAX_SPECIES-1)/2
 //////////////
     
     // misc global variables

--- a/src_common/common_namespace.H
+++ b/src_common/common_namespace.H
@@ -2,7 +2,7 @@ namespace common {
 
 //////////////
 // DO NOT CHANGE THIS VALUE WITHOUT ALSO CHANGING common_namelist.F90
-#define MAX_SPECIES 8
+#define MAX_SPECIES 4
 //////////////
     
     // misc global variables

--- a/src_common/src_F90/common_namelist.F90
+++ b/src_common/src_F90/common_namelist.F90
@@ -1,6 +1,5 @@
 #include <AMReX_Config.H>
 
-
 module common_namelist_module
 
   use iso_c_binding, only: c_char
@@ -9,8 +8,10 @@ module common_namelist_module
   
   implicit none
 
+  !!!!!!!!!!!!!
+  ! DO NOT CHANGE THIS VALUE WITHOUT ALSO CHANGING common_namespace.H
   integer, parameter :: MAX_SPECIES = 4
-  integer, parameter :: LOHI = 2
+  !!!!!!!!!!!!!
 
   double precision,   save :: prob_lo(AMREX_SPACEDIM)
   double precision,   save :: prob_hi(AMREX_SPACEDIM)
@@ -157,7 +158,7 @@ module common_namelist_module
 
   integer,            save :: histogram_unit
   double precision,   save :: density_weights(MAX_SPECIES)
-  integer,            save :: shift_cc_to_boundary(AMREX_SPACEDIM,LOHI)
+  integer,            save :: shift_cc_to_boundary(AMREX_SPACEDIM,2)
 
   double precision,   save :: permittivity
   integer,            save :: wall_mob
@@ -826,7 +827,7 @@ contains
     integer,                intent(inout) :: max_grid_projection_in(AMREX_SPACEDIM-1)
     integer,                intent(inout) :: histogram_unit_in
     double precision,       intent(inout) :: density_weights_in(MAX_SPECIES)
-    integer,                intent(inout) :: shift_cc_to_boundary_in(AMREX_SPACEDIM,LOHI)
+    integer,                intent(inout) :: shift_cc_to_boundary_in(AMREX_SPACEDIM,2)
 
     double precision,       intent(inout) :: eepsilon_in(MAX_SPECIES*MAX_SPECIES)
     double precision,       intent(inout) :: sigma_in(MAX_SPECIES*MAX_SPECIES)

--- a/src_common/src_F90/common_namelist.F90
+++ b/src_common/src_F90/common_namelist.F90
@@ -10,7 +10,8 @@ module common_namelist_module
 
   !!!!!!!!!!!!!
   ! DO NOT CHANGE THIS VALUE WITHOUT ALSO CHANGING common_namespace.H
-  integer, parameter :: MAX_SPECIES = 4
+  integer, parameter :: MAX_SPECIES = 8
+  integer, parameter :: MAX_ELEMENT = 28 ! needs to be MAX_SPECIES*(MAX_SPECIES-1)/2
   !!!!!!!!!!!!!
 
   double precision,   save :: prob_lo(AMREX_SPACEDIM)

--- a/src_compressible/compressible_functions.H
+++ b/src_compressible/compressible_functions.H
@@ -1,8 +1,6 @@
 #ifndef _compressible_functions_H_
 #define _compressible_functions_H_
 
-#define LOHI 2
-
 #include <AMReX.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_ArrayLim.H>

--- a/src_compressible_stag/compressible_functions_stag.H
+++ b/src_compressible_stag/compressible_functions_stag.H
@@ -1,8 +1,6 @@
 #ifndef _compressible_functions_stag_H_
 #define _compressible_functions_stag_H_
 
-#define LOHI 2
-
 #include <AMReX.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_ArrayLim.H>

--- a/src_multispec/ElectroDiffusiveMassFluxdiv.cpp
+++ b/src_multispec/ElectroDiffusiveMassFluxdiv.cpp
@@ -86,7 +86,7 @@ void ElectroDiffusiveMassFlux(const MultiFab& rho,
     }
 
     bool any_shift = false;
-    for (int i=0; i<AMREX_SPACEDIM*LOHI; ++i) {
+    for (int i=0; i<AMREX_SPACEDIM*2; ++i) {
         if (shift_cc_to_boundary[i] == 1) any_shift=true;
     }
 

--- a/src_multispec/multispec_functions.H
+++ b/src_multispec/multispec_functions.H
@@ -1,10 +1,6 @@
 #ifndef _multispec_functions_H_
 #define _multispec_functions_H_
 
-// used for binary diffusion coefficients
-// needs to be MAX_SPECIES*(MAX_SPECIES-1)/2, MAX_SPECIES is in common_functions.H
-#define MAX_ELEMENT 6
-
 #include <AMReX_MultiFab.H>
 
 #include "multispec_functions_F.H"

--- a/src_multispec/src_F90/multispec_namelist.F90
+++ b/src_multispec/src_F90/multispec_namelist.F90
@@ -2,11 +2,9 @@ module multispec_namelist_module
 
   use iso_c_binding, only: c_char
   use amrex_string_module, only: amrex_string_c_to_f, amrex_string_f_to_c
-  use common_namelist_module, only: MAX_SPECIES
+  use common_namelist_module, only: MAX_SPECIES, MAX_ELEMENT
 
   implicit none
-
-  integer, parameter :: MAX_ELEMENT=MAX_SPECIES*(MAX_SPECIES-1)/2
 
   integer,            save :: inverse_type
   integer,            save :: temp_type


### PR DESCRIPTION
Make max_species consistent in namespace and namelist
Remove LOHI since it's hardly used and equal to 2
Move max_element into common namespace and namelist