### PR TITLE
GammaIPlusMatmul should have been inside the else clause. 

### DIFF
--- a/src_multispec/multispec_functions.H
+++ b/src_multispec/multispec_functions.H
@@ -416,10 +416,12 @@ void ComputeGammaLocal(
         } else {
             PopulateX_xxT(nspecies_in, X_xxT, MolarConcN);
         }
-    }
 
     //Compute Gamma
     GammaIPlusMatmul(nspecies_in, GammaN, X_xxT, HessianN);
+
+    }
+
 }
 
 #endif


### PR DESCRIPTION
The difference didn't show up in the original four regression tests. But its clearly wrong when looking at the original Fortran. I verified accuracy by forcing the else condition and comparing the difference in output for `inputs_rtil_spinodal_charges_2d`. 