### PR TITLE
Compressible bc

### DIFF
--- a/src_compressible/boundary.cpp
+++ b/src_compressible/boundary.cpp
@@ -165,6 +165,10 @@ void SetupCWall() {
     }
 }
 
+// in this routine for Dirichlet BC, we set the 
+// value in the ghost cell to be the value of the
+// Dirichlet boundary for temperature, species 
+// fraction and velocities
 void setBC(MultiFab& prim_in, MultiFab& cons_in)
 {
     BL_PROFILE_VAR("setBC()",setBC);
@@ -200,14 +204,14 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 });
             }
 
-            // mass fracations, concentration
+            // mass fractions, concentration
             if (bc_mass_lo[0] == 2 && algorithm_type == 2) {
                 amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (i < 0) {
                         for (int n=0; n<nspecies; ++n) {
-                            prim(i,j,k,6+n)          = 2.*bc_Yk_x_lo[n] - prim(2*lo-i-1,j,k,6+n);
-                            prim(i,j,k,6+nspecies+n) = 2.*bc_Xk_x_lo[n] - prim(2*lo-i-1,j,k,6+nspecies+n);
+                            prim(i,j,k,6+n)          = bc_Yk_x_lo[n];
+                            prim(i,j,k,6+nspecies+n) = bc_Xk_x_lo[n];
                         }
                     }
                 });
@@ -247,7 +251,7 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (i < 0) {
-                        prim(i,j,k,4) = -prim(2*lo-i-1,j,k,4) + 2.*t_lo[0];
+                        prim(i,j,k,4) = t_lo[0];
                         prim(i,j,k,5) = prim(2*lo-i-1,j,k,5);
                     }
                 });
@@ -298,11 +302,11 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (i < 0) {
 
-                        cons(i,j,k,1) = -cons(2*lo-i-1,j,k,1);
+                        cons(i,j,k,1) = 0.0;
                         cons(i,j,k,2) = cons(2*lo-i-1,j,k,2);
                         cons(i,j,k,3) = cons(2*lo-i-1,j,k,3);
 
-                        prim(i,j,k,1) = -prim(2*lo-i-1,j,k,1);
+                        prim(i,j,k,1) = 0.0;
                         prim(i,j,k,2) = prim(2*lo-i-1,j,k,2);
                         prim(i,j,k,3) = prim(2*lo-i-1,j,k,3);
 
@@ -339,9 +343,9 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (i < 0) {
 
-                        prim(i,j,k,1) = -prim(2*lo-i-1,j,k,1);
-                        prim(i,j,k,2) = -prim(2*lo-i-1,j,k,2);
-                        prim(i,j,k,3) = -prim(2*lo-i-1,j,k,3);
+                        prim(i,j,k,1) = 0.0; 
+                        prim(i,j,k,2) = 0.0; 
+                        prim(i,j,k,3) = 0.0; 
                    
                         // thermal & species (+pressure) BCs must be enforced first
                         GpuArray<Real,MAX_SPECIES> fracvec;
@@ -396,14 +400,14 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 });
             }
 
-            // mass fracations, concentration
+            // mass fractions, concentration
             if (bc_mass_hi[0] == 2 && algorithm_type == 2) {
                 amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (i > n_cells[0]-1) {
                         for (int n=0; n<nspecies; ++n) {
-                            prim(i,j,k,6+n)          = 2.*bc_Yk_x_hi[n] - prim(2*hi-i+1,j,k,6+n);
-                            prim(i,j,k,6+nspecies+n) = 2.*bc_Xk_x_hi[n] - prim(2*hi-i+1,j,k,6+nspecies+n);
+                            prim(i,j,k,6+n)          = bc_Yk_x_hi[n];
+                            prim(i,j,k,6+nspecies+n) = bc_Xk_x_hi[n];
                         }
                     }
                 });
@@ -442,7 +446,7 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (i > n_cells[0]-1) {
-                        prim(i,j,k,4) = -prim(2*hi-i+1,j,k,4) + 2.*t_hi[0];
+                        prim(i,j,k,4) = t_hi[0];
                         prim(i,j,k,5) = prim(2*hi-i+1,j,k,5);
                     }
                 });
@@ -494,11 +498,11 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (i > n_cells[0]-1) {
 
-                        cons(i,j,k,1) = -cons(2*hi-i+1,j,k,1);
+                        cons(i,j,k,1) = 0.0;
                         cons(i,j,k,2) = cons(2*hi-i+1,j,k,2);
                         cons(i,j,k,3) = cons(2*hi-i+1,j,k,3);
 
-                        prim(i,j,k,1) = -prim(2*hi-i+1,j,k,1);
+                        prim(i,j,k,1) = 0.0;
                         prim(i,j,k,2) = prim(2*hi-i+1,j,k,2);
                         prim(i,j,k,3) = prim(2*hi-i+1,j,k,3);
 
@@ -536,9 +540,9 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (i > n_cells[0]-1) {
 
-                        prim(i,j,k,1) = -prim(2*hi-i+1,j,k,1);
-                        prim(i,j,k,2) = -prim(2*hi-i+1,j,k,2);
-                        prim(i,j,k,3) = -prim(2*hi-i+1,j,k,3);
+                        prim(i,j,k,1) = 0.0;
+                        prim(i,j,k,2) = 0.0;
+                        prim(i,j,k,3) = 0.0;
                    
                         // thermal & species (+pressure) BCs must be enforced first
                         GpuArray<Real,MAX_SPECIES> fracvec;
@@ -597,8 +601,8 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (j < 0) {
                         for (int n=0; n<nspecies; ++n) {
-                            prim(i,j,k,6+n)          = 2.*bc_Yk_y_lo[n] - prim(i,2*lo-j-1,k,6+n);
-                            prim(i,j,k,6+nspecies+n) = 2.*bc_Xk_y_lo[n] - prim(i,2*lo-j-1,k,6+nspecies+n);
+                            prim(i,j,k,6+n)          = bc_Yk_y_lo[n];
+                            prim(i,j,k,6+nspecies+n) = bc_Xk_y_lo[n];
                         }
                     }
                 });
@@ -618,7 +622,7 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (j < 0) {
-                        prim(i,j,k,4) = -prim(i,2*lo-j-1,k,4) + 2.*t_lo[1];
+                        prim(i,j,k,4) = t_lo[1];
                         prim(i,j,k,5) = prim(i,2*lo-j-1,k,5);
                     }
                 });
@@ -631,11 +635,11 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                     if (j < 0) {
 
                         cons(i,j,k,1) = cons(i,2*lo-j-1,k,1);
-                        cons(i,j,k,2) = -cons(i,2*lo-j-1,k,2);
+                        cons(i,j,k,2) = 0.0;
                         cons(i,j,k,3) = cons(i,2*lo-j-1,k,3);
 
                         prim(i,j,k,1) = prim(i,2*lo-j-1,k,1);
-                        prim(i,j,k,2) = -prim(i,2*lo-j-1,k,2);
+                        prim(i,j,k,2) = 0.0;
                         prim(i,j,k,3) = prim(i,2*lo-j-1,k,3);
 
                         // thermal & species (+pressure) BCs must be enforced first
@@ -671,9 +675,9 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (j < 0) {
 
-                        prim(i,j,k,1) = -prim(i,2*lo-j-1,k,1);
-                        prim(i,j,k,2) = -prim(i,2*lo-j-1,k,2);
-                        prim(i,j,k,3) = -prim(i,2*lo-j-1,k,3);
+                        prim(i,j,k,1) = 0.0;
+                        prim(i,j,k,2) = 0.0;
+                        prim(i,j,k,3) = 0.0;
                    
                         // thermal & species (+pressure) BCs must be enforced first
                         GpuArray<Real,MAX_SPECIES> fracvec;
@@ -734,8 +738,8 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (j > n_cells[1]-1) {
                         for (int n=0; n<nspecies; ++n) {
-                            prim(i,j,k,6+n)          = 2.*bc_Yk_y_hi[n] - prim(i,2*hi-j+1,k,6+n);
-                            prim(i,j,k,6+nspecies+n) = 2.*bc_Xk_y_hi[n] - prim(i,2*hi-j+1,k,6+nspecies+n);
+                            prim(i,j,k,6+n)          = bc_Yk_y_hi[n];
+                            prim(i,j,k,6+nspecies+n) = bc_Xk_y_hi[n];
                         }
                     }
                 });
@@ -755,7 +759,7 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (j > n_cells[1]-1) {
-                        prim(i,j,k,4) = -prim(i,2*hi-j+1,k,4) + 2.*t_hi[1];
+                        prim(i,j,k,4) = t_hi[1];
                         prim(i,j,k,5) = prim(i,2*hi-j+1,k,5);
                     }
                 });
@@ -768,11 +772,11 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                     if (j > n_cells[1]-1) {
 
                         cons(i,j,k,1) = cons(i,2*hi-j+1,k,1);
-                        cons(i,j,k,2) = -cons(i,2*hi-j+1,k,2);
+                        cons(i,j,k,2) = 0.0;
                         cons(i,j,k,3) = cons(i,2*hi-j+1,k,3);
 
                         prim(i,j,k,1) = prim(i,2*hi-j+1,k,1);
-                        prim(i,j,k,2) = -prim(i,2*hi-j+1,k,2);
+                        prim(i,j,k,2) = 0.0;
                         prim(i,j,k,3) = prim(i,2*hi-j+1,k,3);
 
                         // thermal & species (+pressure) BCs must be enforced first
@@ -809,9 +813,9 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (j > n_cells[1]-1) {
 
-                        prim(i,j,k,1) = -prim(i,2*hi-j+1,k,1);
-                        prim(i,j,k,2) = -prim(i,2*hi-j+1,k,2);
-                        prim(i,j,k,3) = -prim(i,2*hi-j+1,k,3);
+                        prim(i,j,k,1) = 0.0;
+                        prim(i,j,k,2) = 0.0;
+                        prim(i,j,k,3) = 0.0;
                    
                         // thermal & species (+pressure) BCs must be enforced first
                         GpuArray<Real,MAX_SPECIES> fracvec;
@@ -870,8 +874,8 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (k < 0) {
                         for (int n=0; n<nspecies; ++n) {
-                            prim(i,j,k,6+n)          = 2.*bc_Yk_z_lo[n] - prim(i,j,2*lo-k-1,6+n);
-                            prim(i,j,k,6+nspecies+n) = 2.*bc_Xk_z_lo[n] - prim(i,j,2*lo-k-1,6+nspecies+n);
+                            prim(i,j,k,6+n)          = bc_Yk_z_lo[n];
+                            prim(i,j,k,6+nspecies+n) = bc_Xk_z_lo[n];
                         }
                     }
                 });
@@ -891,7 +895,7 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (k < 0) {
-                        prim(i,j,k,4) = -prim(i,j,2*lo-k-1,4) + 2.*t_lo[2];
+                        prim(i,j,k,4) = t_lo[2];
                         prim(i,j,k,5) = prim(i,j,2*lo-k-1,5);
                     }
                 });
@@ -905,11 +909,11 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
 
                         cons(i,j,k,1) = cons(i,j,2*lo-k-1,1);
                         cons(i,j,k,2) = cons(i,j,2*lo-k-1,2);
-                        cons(i,j,k,3) = -cons(i,j,2*lo-k-1,3);
+                        cons(i,j,k,3) = 0.0;
 
                         prim(i,j,k,1) = prim(i,j,2*lo-k-1,1);
                         prim(i,j,k,2) = prim(i,j,2*lo-k-1,2);
-                        prim(i,j,k,3) = -prim(i,j,2*lo-k-1,3);
+                        prim(i,j,k,3) = 0.0;;
 
                         // thermal & species (+pressure) BCs must be enforced first
                         GpuArray<Real,MAX_SPECIES> fracvec;
@@ -944,9 +948,9 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (k < 0) {
 
-                        prim(i,j,k,1) = -prim(i,j,2*lo-k-1,1);
-                        prim(i,j,k,2) = -prim(i,j,2*lo-k-1,2);
-                        prim(i,j,k,3) = -prim(i,j,2*lo-k-1,3);
+                        prim(i,j,k,1) = 0.0;
+                        prim(i,j,k,2) = 0.0;
+                        prim(i,j,k,3) = 0.0;
                    
                         // thermal & species (+pressure) BCs must be enforced first
                         GpuArray<Real,MAX_SPECIES> fracvec;
@@ -1001,14 +1005,14 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 });
             }
 
-            // mass fracations, reservoir
+            // mass fractions, reservoir
             if (bc_mass_hi[2] == 2 && algorithm_type == 2) {
                 amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (k > n_cells[2]-1) {
                         for (int n=0; n<nspecies; ++n) {
-                            prim(i,j,k,6+n)          = 2.*bc_Yk_z_hi[n] - prim(i,j,2*hi-k+1,6+n);
-                            prim(i,j,k,6+nspecies+n) = 2.*bc_Xk_z_hi[n] - prim(i,j,2*hi-k+1,6+nspecies+n);
+                            prim(i,j,k,6+n)          = bc_Yk_z_hi[n];
+                            prim(i,j,k,6+nspecies+n) = bc_Xk_z_hi[n];
                         }
                     }
                 });
@@ -1028,7 +1032,7 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (k > n_cells[2]-1) {
-                        prim(i,j,k,4) = -prim(i,j,2*hi-k+1,4) + 2.*t_hi[2];
+                        prim(i,j,k,4) = t_hi[2];
                         prim(i,j,k,5) = prim(i,j,2*hi-k+1,5);
                     }
                 });
@@ -1042,11 +1046,11 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
 
                         cons(i,j,k,1) = cons(i,j,2*hi-k+1,1);
                         cons(i,j,k,2) = cons(i,j,2*hi-k+1,2);
-                        cons(i,j,k,3) = -cons(i,j,2*hi-k+1,3);
+                        cons(i,j,k,3) = 0.0;
 
                         prim(i,j,k,1) = prim(i,j,2*hi-k+1,1);
                         prim(i,j,k,2) = prim(i,j,2*hi-k+1,2);
-                        prim(i,j,k,3) = -prim(i,j,2*hi-k+1,3);
+                        prim(i,j,k,3) = 0.0;
 
                         // thermal & species (+pressure) BCs must be enforced first
                         GpuArray<Real,MAX_SPECIES> fracvec;
@@ -1082,9 +1086,9 @@ void setBC(MultiFab& prim_in, MultiFab& cons_in)
                 {
                     if (k > n_cells[2]-1) {
 
-                        prim(i,j,k,1) = -prim(i,j,2*hi-k+1,1);
-                        prim(i,j,k,2) = -prim(i,j,2*hi-k+1,2);
-                        prim(i,j,k,3) = -prim(i,j,2*hi-k+1,3);
+                        prim(i,j,k,1) = 0.0;
+                        prim(i,j,k,2) = 0.0;
+                        prim(i,j,k,3) = 0.0;
                    
                         // thermal & species (+pressure) BCs must be enforced first
                         GpuArray<Real,MAX_SPECIES> fracvec;


### PR DESCRIPTION
This PR changes how Dirichlet boundaries are handled in both cell-centered and staggered compressible code. The ghost cells now carry the Dirichlet boundaries values rather than a linear extrapolation. As such, the boundary fluxes are doubled in magnitude, and the state of the system is calculated exactly at the boundaries and not in an extrapolated sense. This will make the boundary implementation more accurate, and also prevent unphysical values in the ghost cells arising from extrapolation (such as negative temperature and mass fractions).