### PR TITLE
Ci key fix

### DIFF
--- a/.github/workflows/dependencies/dependencies_nvcc11.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc11.sh
@@ -4,11 +4,6 @@
 #
 # License: BSD-3-Clause-LBNL
 
-# search recursive inside a folder if a file contains tabs
-#
-# @result 0 if no files are found, else 1
-#
-
 set -eu -o pipefail
 
 sudo apt-get -qqq update
@@ -24,25 +19,13 @@ sudo apt-get install -y \
     pkg-config          \
     wget
 
-#sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
-#sudo apt-key add 7fa2af80.pub
-#echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" \
-#    | sudo tee /etc/apt/sources.list.d/cuda.list
-#sudo apt-get update
-#sudo apt-get install -y \
-#    cuda-command-line-tools-11-2 \
-#    cuda-compiler-11-2           \
-#    cuda-cupti-dev-11-2          \
-#    cuda-minimal-build-11-2      \
-#    cuda-nvml-dev-11-2           \
-#    cuda-nvtx-11-2               \
-#    libcufft-11-2                \
-#    libcurand-dev-11-2
-#sudo ln -s cuda-11.2 /usr/local/cuda
+sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
+echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" \
+    | sudo tee /etc/apt/sources.list.d/cuda.list
+
 sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
 sudo apt-get update
-sudo apt-get -y install cuda
+sudo apt-get install -y cuda-11-2
+
+


### PR DESCRIPTION
Update key fetching in the dependencies script for the workflow. Also includes changes to install only specific cuda packages instead of the full suite. Finally, the cuda check will use Cuda ver. 11.2. 