### PR TITLE
Wallspeed fix

### DIFF
--- a/exec/hydro/advance.cpp
+++ b/exec/hydro/advance.cpp
@@ -62,7 +62,10 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
   ///////////////////////////////////////////
 
   for (int d=0; d<AMREX_SPACEDIM; ++d) {
-    umac[d].FillBoundary(geom.periodicity());
+      MultiFabPhysBCDomainVel(umac[d], geom, d);
+      int is_inhomogeneous = 1;
+      MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
+      umac[d].FillBoundary(geom.periodicity());
   }
 
   //////////////////////////////////////////////////
@@ -151,7 +154,10 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
 
   // Compute predictor advective term
   for (int d=0; d<AMREX_SPACEDIM; d++) {
-    umacNew[d].FillBoundary(geom.periodicity());
+      MultiFabPhysBCDomainVel(umacNew[d], geom, d);
+      int is_inhomogeneous = 1;
+      MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
+      umacNew[d].FillBoundary(geom.periodicity());
   }
 
   /*
@@ -222,6 +228,17 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
   for (int d=0; d<AMREX_SPACEDIM; d++) {
     MultiFab::Copy(umac[d], umacNew[d], 0, 0, 1, 0);
   }
+
+  // these calls are redundant with the calls at the beginning of the time step
+  // except for diagnostics which can rely on the ghost cells for stencils such
+  // as vorticity
+  for (int d=0; d<AMREX_SPACEDIM; d++) {
+      MultiFabPhysBCDomainVel(umac[d], geom, d);
+      int is_inhomogeneous = 1;
+      MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
+      umac[d].FillBoundary(geom.periodicity());
+  }
+  
   //////////////////////////////////////////////////
 
 }

--- a/exec/immersed_boundary/channel_dumbbell/advance.cpp
+++ b/exec/immersed_boundary/channel_dumbbell/advance.cpp
@@ -181,7 +181,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         umac[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[i], geom, i);
-        MultiFabPhysBCMacVel(umac[i], geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i], geom, i, is_inhomogeneous);
     }
 
 
@@ -234,7 +235,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         uMom[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(uMom[i], geom, i);
-        MultiFabPhysBCMacVel(uMom[i], geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(uMom[i], geom, i, is_inhomogeneous);
     }
 
     MkAdvMFluxdiv(umac, uMom, advFluxdiv, dx, 0);
@@ -381,14 +383,15 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
     for (int d=0; d<AMREX_SPACEDIM; d++) {
         umacNew[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
 
         MultiFab::Copy(uMom[d], umacNew[d], 0, 0, 1, 0);
         uMom[d].mult(1.0, 1);
 
         uMom[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(uMom[d], geom, d);
-        MultiFabPhysBCMacVel(uMom[d], geom, d);
+        MultiFabPhysBCMacVel(uMom[d], geom, d, is_inhomogeneous);
     }
 
     MkAdvMFluxdiv(umacNew,uMom,advFluxdivPred,dx,0);

--- a/exec/immersed_boundary/channel_dumbbell/main_driver.cpp
+++ b/exec/immersed_boundary/channel_dumbbell/main_driver.cpp
@@ -368,7 +368,8 @@ void main_driver(const char * argv) {
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         umac[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[i], geom, i);
-        MultiFabPhysBCMacVel(umac[i], geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i], geom, i, is_inhomogeneous);
     }
 
 

--- a/exec/immersed_boundary/channel_multiblob/advance.cpp
+++ b/exec/immersed_boundary/channel_multiblob/advance.cpp
@@ -182,7 +182,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         umac[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[i], geom, i);
-        MultiFabPhysBCMacVel(umac[i], geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i], geom, i, is_inhomogeneous);
     }
 
 
@@ -234,7 +235,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         MultiFab::Copy(umac_buffer[d], umac[d], 0, 0, 1, umac[d].nGrow());
         umac_buffer[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[d], geom, d);
-        MultiFabPhysBCMacVel(umac[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
     }
 
     ib_mbc.ResetPredictor(ib_lev);
@@ -309,7 +311,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
 
         uMom[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(uMom[d], geom, d);
-        MultiFabPhysBCMacVel(uMom[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(uMom[d], geom, d, is_inhomogeneous);
     }
 
     // Compute advective fluxes: advFluxdiv = - D(\rho uu^n) = - D(u^n uMom)
@@ -363,7 +366,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
     for (int d=0; d<AMREX_SPACEDIM; ++d) {
         umacNew[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
     }
 
 
@@ -385,7 +389,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         MultiFab::Copy(umacNew_buffer[d], umacNew[d], 0, 0, 1, umacNew[d].nGrow());
         umacNew_buffer[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
     }
 
     ib_mbc.ResetMarkers(ib_lev);
@@ -514,7 +519,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
 
         uMom[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(uMom[d], geom, d);
-        MultiFabPhysBCMacVel(uMom[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(uMom[d], geom, d, is_inhomogeneous);
     }
 
     // Compute advective fluxes for the corrector:

--- a/exec/immersed_boundary/channel_multiblob/main_driver.cpp
+++ b/exec/immersed_boundary/channel_multiblob/main_driver.cpp
@@ -438,7 +438,8 @@ void main_driver(const char * argv) {
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         umac[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[i], geom, i);
-        MultiFabPhysBCMacVel(umac[i], geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i], geom, i, is_inhomogeneous);
     }
 
 

--- a/exec/immersed_boundary/channel_rigid/advance.cpp
+++ b/exec/immersed_boundary/channel_rigid/advance.cpp
@@ -160,7 +160,8 @@ void advance(std::array<MultiFab, AMREX_SPACEDIM> & umac,
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         umac[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[i], i, geom, i);
-        MultiFabPhysBCMacVel(umac[i], i, geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i], i, geom, i, is_inhomogeneous);
     }
 
 
@@ -378,7 +379,8 @@ void advance(std::array<MultiFab, AMREX_SPACEDIM> & umac,
         // momentum boundary conditions
         uMom[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(uMom[d], d, geom, d);
-        MultiFabPhysBCMacVel(uMom[d], d, geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(uMom[d], d, geom, d, is_inhomogeneous);
     }
 
     // advective momentum flux terms
@@ -471,7 +473,8 @@ void advance(std::array<MultiFab, AMREX_SPACEDIM> & umac,
      for (int d=0; d<AMREX_SPACEDIM; d++) {
         umacNew[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], d, geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], d, geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], d, geom, d, is_inhomogeneous);
 
         MultiFab::Copy(uMom[d], umacNew[d], 0, 0, 1, 1);
 
@@ -481,7 +484,8 @@ void advance(std::array<MultiFab, AMREX_SPACEDIM> & umac,
         // momentum boundary conditions
         uMom[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(uMom[d], d, geom, d);
-        MultiFabPhysBCMacVel(uMom[d], d, geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(uMom[d], d, geom, d, is_inhomogeneous);
      }
 
     // advective momentum flux terms

--- a/exec/immersed_boundary/channel_rigid/main_driver.cpp
+++ b/exec/immersed_boundary/channel_rigid/main_driver.cpp
@@ -351,7 +351,8 @@ void main_driver(const char * argv) {
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         umac[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[i], i, geom, i);
-        MultiFabPhysBCMacVel(umac[i], i, geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i], i, geom, i, is_inhomogeneous);
     }
 
 

--- a/exec/immersed_boundary/flagellum/advance_CN.cpp
+++ b/exec/immersed_boundary/flagellum/advance_CN.cpp
@@ -180,7 +180,8 @@ void advance_CN(std::array<MultiFab, AMREX_SPACEDIM >& umac,
     for (int d=0; d<AMREX_SPACEDIM; d++) {
         umac[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[d], geom, d);
-        MultiFabPhysBCMacVel(umac[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
     }
 
 
@@ -206,7 +207,8 @@ void advance_CN(std::array<MultiFab, AMREX_SPACEDIM >& umac,
         MultiFab::Copy(umac_buffer[d], umac[d], 0, 0, 1, umac[d].nGrow());
         umac_buffer[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[d], geom, d);
-        MultiFabPhysBCMacVel(umac[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
     }
 
     ib_mc.ResetPredictor(0);
@@ -272,7 +274,8 @@ void advance_CN(std::array<MultiFab, AMREX_SPACEDIM >& umac,
 
         uMom[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(uMom[d], geom, d);
-        MultiFabPhysBCMacVel(uMom[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(uMom[d], geom, d, is_inhomogeneous);
     }
 
     // Compute advective fluxes: advFluxdiv = - D(\rho uu^n) = - D(u^n uMom)
@@ -324,7 +327,8 @@ void advance_CN(std::array<MultiFab, AMREX_SPACEDIM >& umac,
     for (int d=0; d<AMREX_SPACEDIM; ++d) {
         umacNew[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
     }
 
 
@@ -348,7 +352,8 @@ void advance_CN(std::array<MultiFab, AMREX_SPACEDIM >& umac,
         MultiFab::Copy(umacNew_buffer[d], umacNew[d], 0, 0, 1, umac[d].nGrow());
         umacNew_buffer[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
     }
 
     ib_mc.ResetMarkers(0);
@@ -413,7 +418,8 @@ void advance_CN(std::array<MultiFab, AMREX_SPACEDIM >& umac,
 
         uMom[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(uMom[d], geom, d);
-        MultiFabPhysBCMacVel(uMom[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(uMom[d], geom, d, is_inhomogeneous);
     }
 
     // Compute advective fluxes at the midpoint:
@@ -472,7 +478,8 @@ void advance_CN(std::array<MultiFab, AMREX_SPACEDIM >& umac,
     for (int d=0; d<AMREX_SPACEDIM; d++) {
         umacNew[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
     }
 
     // Update solution, and we're done!

--- a/exec/immersed_boundary/flagellum/advance_midpoint.cpp
+++ b/exec/immersed_boundary/flagellum/advance_midpoint.cpp
@@ -190,7 +190,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
     for (int d=0; d<AMREX_SPACEDIM; d++) {
         umac[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[d], geom, d);
-        MultiFabPhysBCMacVel(umac[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
     }
 
 
@@ -216,7 +217,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         MultiFab::Copy(umac_buffer[d], umac[d], 0, 0, 1, umac[d].nGrow());
         umac_buffer[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[d], geom, d);
-        MultiFabPhysBCMacVel(umac[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
     }
 
     ib_mc.ResetPredictor(0);
@@ -280,7 +282,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
 
         uMom[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(uMom[d], geom, d);
-        MultiFabPhysBCMacVel(uMom[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(uMom[d], geom, d, is_inhomogeneous);
     }
 
     // Compute advective fluxes: advFluxdiv = - D(\rho uu^n) = - D(u^n uMom)
@@ -323,7 +326,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
     for (int d=0; d<AMREX_SPACEDIM; ++d) {
         umacNew[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
     }
 
 
@@ -347,7 +351,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         MultiFab::Copy(umacNew_buffer[d], umacNew[d], 0, 0, 1, umac[d].nGrow());
         umacNew_buffer[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
     }
 
     ib_mc.ResetMarkers(0);
@@ -411,7 +416,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
 
         uMom[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(uMom[d], geom, d);
-        MultiFabPhysBCMacVel(uMom[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(uMom[d], geom, d, is_inhomogeneous);
     }
 
     // Compute advective fluxes at the midpoint:
@@ -459,7 +465,8 @@ void advance(std::array< MultiFab, AMREX_SPACEDIM >& umac,
     for (int d=0; d<AMREX_SPACEDIM; d++) {
         umacNew[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
     }
 
     // Update solution, and we're done!

--- a/exec/immersed_boundary/flagellum/advance_stokes.cpp
+++ b/exec/immersed_boundary/flagellum/advance_stokes.cpp
@@ -117,7 +117,8 @@ void advance_stokes(std::array<MultiFab, AMREX_SPACEDIM >& umac,
     for (int d=0; d<AMREX_SPACEDIM; d++) {
         umac[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[d], geom, d);
-        MultiFabPhysBCMacVel(umac[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
     }
 
 
@@ -141,7 +142,8 @@ void advance_stokes(std::array<MultiFab, AMREX_SPACEDIM >& umac,
         MultiFab::Copy(umacNew_buffer[d], umacNew[d], 0, 0, 1, umac[d].nGrow());
         umacNew_buffer[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
     }
 
     ib_mc.ResetMarkers(0);
@@ -214,7 +216,8 @@ void advance_stokes(std::array<MultiFab, AMREX_SPACEDIM >& umac,
     for (int d=0; d<AMREX_SPACEDIM; d++) {
         umacNew[d].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umacNew[d], geom, d);
-        MultiFabPhysBCMacVel(umacNew[d], geom, d);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umacNew[d], geom, d, is_inhomogeneous);
     }
 
     // Update solution, and we're done!

--- a/exec/immersed_boundary/flagellum/main_driver.cpp
+++ b/exec/immersed_boundary/flagellum/main_driver.cpp
@@ -555,7 +555,8 @@ void main_driver(const char * argv) {
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         umac[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[i], geom, i);
-        MultiFabPhysBCMacVel(umac[i], geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i], geom, i, is_inhomogeneous);
     }
 
     BL_PROFILE_VAR_STOP(ICwork);

--- a/exec/lib_hydro/demo/main_driver.cpp
+++ b/exec/lib_hydro/demo/main_driver.cpp
@@ -288,7 +288,8 @@ void main_driver(const char * argv) {
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         umac[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(umac[i], geom, i);
-        MultiFabPhysBCMacVel(umac[i], geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i], geom, i, is_inhomogeneous);
     }
 
 

--- a/exec/multispec/AdvanceTimestepBousq.cpp
+++ b/exec/multispec/AdvanceTimestepBousq.cpp
@@ -258,7 +258,8 @@ void AdvanceTimestepBousq(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         // set normal velocity of physical domain boundaries
         MultiFabPhysBCDomainVel(umac[i],geom,i);
         // set transverse velocity behind physical boundaries
-        MultiFabPhysBCMacVel(umac[i],geom,i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
         // fill periodic and interior ghost cells
         umac[i].FillBoundary(geom.periodicity());
     }
@@ -329,7 +330,8 @@ void AdvanceTimestepBousq(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         // set normal velocity of physical domain boundaries
         MultiFabPhysBCDomainVel(umac[i],geom,i);
         // set transverse velocity behind physical boundaries
-        MultiFabPhysBCMacVel(umac[i],geom,i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
         // fill periodic and interior ghost cells
         umac[i].FillBoundary(geom.periodicity());
     }
@@ -633,7 +635,8 @@ void AdvanceTimestepBousq(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         // set normal velocity of physical domain boundaries
         MultiFabPhysBCDomainVel(umac[i],geom,i);
         // set transverse velocity behind physical boundaries
-        MultiFabPhysBCMacVel(umac[i],geom,i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
         // fill periodic and interior ghost cells
         umac[i].FillBoundary(geom.periodicity());
     }
@@ -695,7 +698,8 @@ void AdvanceTimestepBousq(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         // set normal velocity of physical domain boundaries
         MultiFabPhysBCDomainVel(umac[i],geom,i);
         // set transverse velocity behind physical boundaries
-        MultiFabPhysBCMacVel(umac[i],geom,i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
         // fill periodic and interior ghost cells
         umac[i].FillBoundary(geom.periodicity());
     }

--- a/exec/multispec/AdvanceTimestepInertial.cpp
+++ b/exec/multispec/AdvanceTimestepInertial.cpp
@@ -283,7 +283,8 @@ void AdvanceTimestepInertial(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         // set normal velocity of physical domain boundaries
         MultiFabPhysBCDomainVel(umac[i],geom,i);
         // set transverse velocity behind physical boundaries
-        MultiFabPhysBCMacVel(umac[i],geom,i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
         // fill periodic and interior ghost cells
         umac[i].FillBoundary(geom.periodicity());
     }
@@ -369,7 +370,8 @@ void AdvanceTimestepInertial(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         // set normal velocity of physical domain boundaries
         MultiFabPhysBCDomainVel(umac[i],geom,i);
         // set transverse velocity behind physical boundaries
-        MultiFabPhysBCMacVel(umac[i],geom,i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
         // fill periodic and interior ghost cells
         umac[i].FillBoundary(geom.periodicity());
     }
@@ -549,7 +551,8 @@ void AdvanceTimestepInertial(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         // set normal velocity of physical domain boundaries
         MultiFabPhysBCDomainVel(umac[i],geom,i);
         // set transverse velocity behind physical boundaries
-        MultiFabPhysBCMacVel(umac[i],geom,i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
         // fill periodic and interior ghost cells
         umac[i].FillBoundary(geom.periodicity());
     }
@@ -619,7 +622,8 @@ void AdvanceTimestepInertial(std::array< MultiFab, AMREX_SPACEDIM >& umac,
         // set normal velocity of physical domain boundaries
         MultiFabPhysBCDomainVel(umac[i],geom,i);
         // set transverse velocity behind physical boundaries
-        MultiFabPhysBCMacVel(umac[i],geom,i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
         // fill periodic and interior ghost cells
         umac[i].FillBoundary(geom.periodicity());
     }

--- a/exec/multispec/main_driver.cpp
+++ b/exec/multispec/main_driver.cpp
@@ -359,7 +359,8 @@ void main_driver(const char* argv)
         // set normal velocity of physical domain boundaries
         MultiFabPhysBCDomainVel(umac[i],geom,i);
         // set transverse velocity behind physical boundaries
-        MultiFabPhysBCMacVel(umac[i],geom,i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
         // fill periodic and interior ghost cells
         umac[i].FillBoundary(geom.periodicity());
         // protect against roundoff issues and sync up
@@ -377,7 +378,8 @@ void main_driver(const char* argv)
                 // set normal velocity of physical domain boundaries
                 MultiFabPhysBCDomainVel(umac[i],geom,i);
                 // set transverse velocity behind physical boundaries
-                MultiFabPhysBCMacVel(umac[i],geom,i);
+                int is_inhomogeneous = 1;
+                MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
                 // fill periodic and interior ghost cells
                 umac[i].FillBoundary(geom.periodicity());
             }

--- a/src_common/MultiFabPhysBC.cpp
+++ b/src_common/MultiFabPhysBC.cpp
@@ -347,7 +347,7 @@ void MultiFabPhysBCDomainVel(MultiFab& vel, const Geometry& geom, int dim) {
 // Set the value of tranverse ghost cells to +/- the reflection of the interior
 // (+ for slip walls, - for no-slip).
 // We fill all the ghost cells - they are needed for Perskin kernels.
-void MultiFabPhysBCMacVel(MultiFab& vel, const Geometry& geom, int dim) {
+void MultiFabPhysBCMacVel(MultiFab& vel, const Geometry& geom, int dim, int is_inhomogeneous) {
 
     BL_PROFILE_VAR("MultiFabPhysBCMacVel()",MultiFabPhysBCMacVel);
     
@@ -384,7 +384,7 @@ void MultiFabPhysBCMacVel(MultiFab& vel, const Geometry& geom, int dim) {
                 amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (i < dom.smallEnd(0)) {
-                        data(i,j,k) = 2.*wallspeed_x_lo[dim] - data(-i-1,j,k);
+                        data(i,j,k) = is_inhomogeneous*2.*wallspeed_x_lo[dim] - data(-i-1,j,k);
                     }
                 });
             }
@@ -402,7 +402,7 @@ void MultiFabPhysBCMacVel(MultiFab& vel, const Geometry& geom, int dim) {
                 amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (i > dom.bigEnd(0)) {
-                        data(i,j,k) = 2.*wallspeed_x_hi[dim] - data(2*dom.bigEnd(0)-i+1,j,k);
+                        data(i,j,k) = is_inhomogeneous*2.*wallspeed_x_hi[dim] - data(2*dom.bigEnd(0)-i+1,j,k);
                     }
                 });
             }
@@ -423,7 +423,7 @@ void MultiFabPhysBCMacVel(MultiFab& vel, const Geometry& geom, int dim) {
                 amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (j < dom.smallEnd(1)) {
-                        data(i,j,k) = 2.*wallspeed_y_lo[dim] - data(i,-j-1,k);
+                        data(i,j,k) = is_inhomogeneous*2.*wallspeed_y_lo[dim] - data(i,-j-1,k);
                     }
                 });
             }
@@ -441,7 +441,7 @@ void MultiFabPhysBCMacVel(MultiFab& vel, const Geometry& geom, int dim) {
                 amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (j > dom.bigEnd(1)) {
-                        data(i,j,k) = 2.*wallspeed_y_hi[dim] - data(i,2*dom.bigEnd(1)-j+1,k);
+                        data(i,j,k) = is_inhomogeneous*2.*wallspeed_y_hi[dim] - data(i,2*dom.bigEnd(1)-j+1,k);
                     }
                 });
             }
@@ -463,7 +463,7 @@ void MultiFabPhysBCMacVel(MultiFab& vel, const Geometry& geom, int dim) {
                 amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (k < dom.smallEnd(2)) {
-                        data(i,j,k) = 2.*wallspeed_z_lo[dim] - data(i,j,-k-1);
+                        data(i,j,k) = is_inhomogeneous*2.*wallspeed_z_lo[dim] - data(i,j,-k-1);
                     }
                 });
             }
@@ -481,7 +481,7 @@ void MultiFabPhysBCMacVel(MultiFab& vel, const Geometry& geom, int dim) {
                 amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (k > dom.bigEnd(2)) {
-                        data(i,j,k) = 2.*wallspeed_z_hi[dim] - data(i,j,2*dom.bigEnd(2)-k+1);
+                        data(i,j,k) = is_inhomogeneous*2.*wallspeed_z_hi[dim] - data(i,j,2*dom.bigEnd(2)-k+1);
                     }
                 });
             }

--- a/src_common/common_functions.H
+++ b/src_common/common_functions.H
@@ -163,7 +163,7 @@ void MultiFabPhysBC(MultiFab& data, const Geometry& geom, int scomp, int ncomp, 
 
 void MultiFabPhysBCDomainVel(MultiFab& vel, const Geometry& geom, int dim);
 
-void MultiFabPhysBCMacVel(MultiFab& vel, const Geometry& geom, int dim);
+void MultiFabPhysBCMacVel(MultiFab& vel, const Geometry& geom, int dim, int is_inhomogeneous=0);
 
 void ZeroEdgevalWalls(std::array<MultiFab, AMREX_SPACEDIM>& edge, const Geometry& geom,
                       int scomp, int ncomp);

--- a/src_common/common_functions.cpp
+++ b/src_common/common_functions.cpp
@@ -1117,23 +1117,23 @@ void InitializeCommonNamespace() {
     }
 
     if (wallspeed_x_lo[0] != 0.) {
-        Abort("wallspeed_x_lo[0] must be 0");
+        Abort("you are specifying a normal velocity on a wall; wallspeed_x_lo[0] must be 0");
     }
     if (wallspeed_x_hi[0] != 0.) {
-        Abort("wallspeed_x_hi[0] must be 0");
+        Abort("you are specifying a normal velocity on a wall; wallspeed_x_hi[0] must be 0");
     }
     if (wallspeed_y_lo[1] != 0.) {
-        Abort("wallspeed_y_lo[1] must be 0");
+        Abort("you are specifying a normal velocity on a wall; wallspeed_y_lo[1] must be 0");
     }
     if (wallspeed_y_hi[1] != 0.) {
-        Abort("wallspeed_y_hi[1] must be 0");
+        Abort("you are specifying a normal velocity on a wall; wallspeed_y_hi[1] must be 0");
     }
 #if (AMREX_SPACEDIM == 3)
     if (wallspeed_z_lo[2] != 0.) {
-        Abort("wallspeed_z_lo[2] must be 0");
+        Abort("you are specifying a normal velocity on a wall; wallspeed_z_lo[2] must be 0");
     }
     if (wallspeed_z_hi[2] != 0.) {
-        Abort("wallspeed_z_hi[2] must be 0");
+        Abort("you are specifying a normal velocity on a wall; wallspeed_z_hi[2] must be 0");
     }
 #endif
     

--- a/src_gmres/ApplyMatrix.cpp
+++ b/src_gmres/ApplyMatrix.cpp
@@ -46,7 +46,7 @@ void ApplyMatrix(std::array<MultiFab, AMREX_SPACEDIM> & b_u,
     for (int i=0; i<AMREX_SPACEDIM; ++i) {
         x_u[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(x_u[i], geom,i);
-        MultiFabPhysBCMacVel(x_u[i], geom,i,is_inhomogeneous);
+        MultiFabPhysBCMacVel(x_u[i], geom, i, is_inhomogeneous);
     }
 
     x_p.FillBoundary(geom.periodicity());

--- a/src_gmres/ApplyMatrix.cpp
+++ b/src_gmres/ApplyMatrix.cpp
@@ -14,7 +14,8 @@ void ApplyMatrix(std::array<MultiFab, AMREX_SPACEDIM> & b_u,
                  const std::array<MultiFab, NUM_EDGE> & beta_ed,
                  const MultiFab                       & gamma,
                  const Real                           & theta_alpha,
-                 const Geometry & geom) {
+                 const Geometry                       & geom,
+                 int                                    is_inhomogeneous) {
 
     BL_PROFILE_VAR("ApplyMatrix()", ApplyMatrix);
 
@@ -45,7 +46,7 @@ void ApplyMatrix(std::array<MultiFab, AMREX_SPACEDIM> & b_u,
     for (int i=0; i<AMREX_SPACEDIM; ++i) {
         x_u[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(x_u[i], geom,i);
-        MultiFabPhysBCMacVel(x_u[i], geom,i);
+        MultiFabPhysBCMacVel(x_u[i], geom,i,is_inhomogeneous);
     }
 
     x_p.FillBoundary(geom.periodicity());

--- a/src_gmres/GMRES.cpp
+++ b/src_gmres/GMRES.cpp
@@ -101,8 +101,7 @@ void GMRES::Solve (std::array<MultiFab, AMREX_SPACEDIM> & b_u, MultiFab & b_p,
             MultiFabPhysBCMacVel(r_u[i], geom, i, is_inhomogeneous);
         }
 
-        ApplyMatrix(tmp_u, tmp_p, r_u, r_p,
-                    alpha_fc, beta, beta_ed, gamma, theta_alpha, geom,
+        ApplyMatrix(tmp_u, tmp_p, r_u, r_p, alpha_fc, beta, beta_ed, gamma, theta_alpha, geom,
                     is_inhomogeneous);
 
         MultiFab::Subtract(b_p, tmp_p, 0, 0, 1, 0);

--- a/src_gmres/GMRES.cpp
+++ b/src_gmres/GMRES.cpp
@@ -91,17 +91,19 @@ void GMRES::Solve (std::array<MultiFab, AMREX_SPACEDIM> & b_u, MultiFab & b_p,
         // then apply the operator
         // subtract the result from the rhs
 
+        int is_inhomogeneous = 1;
+        
         r_p.setVal(0.);
         MultiFabPhysBC(r_p, geom, 0, 1, PRES_BC_COMP);
 
         for (int i=0; i<AMREX_SPACEDIM; ++i ) {
             r_u[i].setVal(0.);
-            int is_inhomogeneous = 1;
             MultiFabPhysBCMacVel(r_u[i], geom, i, is_inhomogeneous);
         }
 
         ApplyMatrix(tmp_u, tmp_p, r_u, r_p,
-                    alpha_fc, beta, beta_ed, gamma, theta_alpha, geom);
+                    alpha_fc, beta, beta_ed, gamma, theta_alpha, geom,
+                    is_inhomogeneous);
 
         MultiFab::Subtract(b_p, tmp_p, 0, 0, 1, 0);
         for (int i=0; i<AMREX_SPACEDIM; ++i) {

--- a/src_gmres/GMRES.cpp
+++ b/src_gmres/GMRES.cpp
@@ -96,7 +96,8 @@ void GMRES::Solve (std::array<MultiFab, AMREX_SPACEDIM> & b_u, MultiFab & b_p,
 
         for (int i=0; i<AMREX_SPACEDIM; ++i ) {
             r_u[i].setVal(0.);
-            MultiFabPhysBCMacVel(r_u[i], geom, i);
+            int is_inhomogeneous = 1;
+            MultiFabPhysBCMacVel(r_u[i], geom, i, is_inhomogeneous);
         }
 
         ApplyMatrix(tmp_u, tmp_p, r_u, r_p,

--- a/src_gmres/gmres_functions.H
+++ b/src_gmres/gmres_functions.H
@@ -27,7 +27,8 @@ void ApplyMatrix(std::array<MultiFab, AMREX_SPACEDIM> & b_u,
                  const std::array<MultiFab, NUM_EDGE> & beta_ed,
                  const MultiFab & gamma,
                  const Real & theta_alpha,
-                 const Geometry & geom);
+                 const Geometry & geom,
+                 int is_inhomogeneous = 0);
 
 void UpdateSol(std::array<MultiFab, AMREX_SPACEDIM> & x_u,
                MultiFab & x_p,

--- a/src_hydro/AddMFluctuations.cpp
+++ b/src_hydro/AddMFluctuations.cpp
@@ -95,6 +95,7 @@ void addMomFluctuations_stag(std::array< MultiFab, AMREX_SPACEDIM >& m_old,
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         m_old[i].FillBoundary(geom.periodicity());
         MultiFabPhysBCDomainVel(m_old[i], geom,i);
-        MultiFabPhysBCMacVel(m_old[i], geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(m_old[i], geom, i, is_inhomogeneous);
     }
 }

--- a/src_hydro/MacProj_hydro.cpp
+++ b/src_hydro/MacProj_hydro.cpp
@@ -116,7 +116,8 @@ MacProj_hydro (std::array< MultiFab, AMREX_SPACEDIM >& umac,
 
       // Do apply BCs so that all ghost cells are filled
       MultiFabPhysBCDomainVel(umac[d], geom, d);
-      MultiFabPhysBCMacVel(umac[d], geom, d);
+      int is_inhomogeneous = 1;
+      MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
     }
 }
 

--- a/src_hydro/MacProj_hydro.cpp
+++ b/src_hydro/MacProj_hydro.cpp
@@ -112,12 +112,11 @@ MacProj_hydro (std::array< MultiFab, AMREX_SPACEDIM >& umac,
 
     // fill periodic ghost cells
     for (int d = 0; d < AMREX_SPACEDIM; d++) {
-      umac[d].FillBoundary(geom.periodicity());
-
       // Do apply BCs so that all ghost cells are filled
       MultiFabPhysBCDomainVel(umac[d], geom, d);
       int is_inhomogeneous = 1;
       MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
+      umac[d].FillBoundary(geom.periodicity());
     }
 }
 

--- a/src_hydro/advance.cpp
+++ b/src_hydro/advance.cpp
@@ -226,7 +226,10 @@ void advanceLowMach(  std::array< MultiFab, AMREX_SPACEDIM >& umac,
   ///////////////////////////////////////////
 
   for (int d=0; d<AMREX_SPACEDIM; ++d) {
-    umac[d].FillBoundary(geom.periodicity());
+      MultiFabPhysBCDomainVel(umac[d], geom, d);
+      int is_inhomogeneous = 1;
+      MultiFabPhysBCMacVel(umac[d], geom, d, is_inhomogeneous);
+      umac[d].FillBoundary(geom.periodicity());
   }
 
   //////////////////////////
@@ -269,7 +272,10 @@ void advanceLowMach(  std::array< MultiFab, AMREX_SPACEDIM >& umac,
   }
 
   for (int d=0; d<AMREX_SPACEDIM; d++) {
-    uMom[d].FillBoundary(geom.periodicity());
+      MultiFabPhysBCDomainVel(uMom[d], geom, d);
+      int is_inhomogeneous = 1;
+      MultiFabPhysBCMacVel(uMom[d], geom, d, is_inhomogeneous);
+      uMom[d].FillBoundary(geom.periodicity());
   }
 
   MkAdvMFluxdiv(umac,uMom,advFluxdiv,dx,0);
@@ -310,6 +316,9 @@ void advanceLowMach(  std::array< MultiFab, AMREX_SPACEDIM >& umac,
     // let rho = 1
     uMom[d].mult(1.0, 1);
 
+    MultiFabPhysBCDomainVel(uMom[d], geom, d);
+    int is_inhomogeneous = 1;
+    MultiFabPhysBCMacVel(uMom[d], geom, d, is_inhomogeneous);
     uMom[d].FillBoundary(geom.periodicity());
   }
 

--- a/src_hydro/advance.cpp
+++ b/src_hydro/advance.cpp
@@ -89,7 +89,8 @@ void advanceStokes(std::array< MultiFab, AMREX_SPACEDIM >& umac,
 
     for (int i=0; i<AMREX_SPACEDIM; i++) {
         MultiFabPhysBCDomainVel(umac[i], geom, i);
-        MultiFabPhysBCMacVel(umac[i], geom, i);
+        int is_inhomogeneous = 1;
+        MultiFabPhysBCMacVel(umac[i], geom, i, is_inhomogeneous);
         umac[i].FillBoundary(geom.periodicity());
     }
 }

--- a/src_multispec/InitialProjection.cpp
+++ b/src_multispec/InitialProjection.cpp
@@ -173,7 +173,8 @@ void InitialProjection(std::array< MultiFab, AMREX_SPACEDIM >& umac,
             // set normal velocity of physical domain boundaries
             MultiFabPhysBCDomainVel(umac[i],geom,i);
             // set transverse velocity behind physical boundaries
-            MultiFabPhysBCMacVel(umac[i],geom,i);
+            int is_inhomogeneous = 1;
+            MultiFabPhysBCMacVel(umac[i],geom,i,is_inhomogeneous);
             // fill periodic and interior ghost cells
             umac[i].FillBoundary(geom.periodicity());
         }


### PR DESCRIPTION
Fix moving wall implementation - need to split MultiFabPhysBC into homogeneous and inhomogeneous versions, and call the inhomogeneous version at all times until the GMRES solver starts.