### PR TITLE
Fix a bug when using amrex::MPMD

### DIFF
--- a/exec/compressible_stag_mui/SPPARKS_MUI/app_surfchemtest.h
+++ b/exec/compressible_stag_mui/SPPARKS_MUI/app_surfchemtest.h
@@ -136,6 +136,8 @@ class AppSurfchemtest : public AppLattice {
   amrex::MultiFab mf;
   amrex::iMultiFab imf;
   std::unique_ptr<amrex::MPMD::Copier> mpmd_copier;
+  std::unique_ptr<amrex::MultiFab> mf2;
+  std::unique_ptr<amrex::iMultiFab> imf2;
 
     void amrex_send_intval();
     void amrex_recv_dblval();


### PR DESCRIPTION
The domain decomposition on the KMC side might split an FHD cell between two
different MPI processes.  This commit fixes a bug that did not take this
into account.