### PR TITLE
Add BDS Edge State Projection

### DIFF
--- a/exec/multispec/AdvanceTimestepBousq.cpp
+++ b/exec/multispec/AdvanceTimestepBousq.cpp
@@ -55,6 +55,7 @@ void AdvanceTimestepBousq(std::array< MultiFab, AMREX_SPACEDIM >& umac,
 
     // For BDS we need to project edge states onto constraints
     // int proj_type = (use_charged_fluid && electroneutral) ? 4 : 3;
+    int proj_type = 3;
     
     Real theta_alpha = 1./dt;
 
@@ -401,7 +402,7 @@ void AdvanceTimestepBousq(std::array< MultiFab, AMREX_SPACEDIM >& umac,
       bds_force.FillBoundary(geom.periodicity());
 
       // bds increments rho_update with the advection term
-      BDS(rho_update, nspecies, SPEC_BC_COMP, rho_old, umac_tmp, bds_force, geom, 0.5*dt);
+      BDS(rho_update, nspecies, SPEC_BC_COMP, rho_old, umac_tmp, bds_force, geom, 0.5*dt, proj_type);
       
     } else if (advection_type == 0) {
 
@@ -555,7 +556,7 @@ void AdvanceTimestepBousq(std::array< MultiFab, AMREX_SPACEDIM >& umac,
       MultiFab::Copy(bds_force,rho_update,0,0,nspecies,0);
       bds_force.FillBoundary(geom.periodicity());
       
-      BDS(rho_update, nspecies, SPEC_BC_COMP, rho_old, umac_tmp, bds_force, geom, dt);
+      BDS(rho_update, nspecies, SPEC_BC_COMP, rho_old, umac_tmp, bds_force, geom, dt, proj_type);
 							       
     } else if (advection_type == 0) {
         // compute adv_mass_fluxdiv = -rho_i^{n+1/2} * v^n and

--- a/exec/multispec/AdvanceTimestepInertial.cpp
+++ b/exec/multispec/AdvanceTimestepInertial.cpp
@@ -149,7 +149,7 @@ void AdvanceTimestepInertial(std::array< MultiFab, AMREX_SPACEDIM >& umac,
 	MultiFab::Copy(bds_force,rho_update,0,0,nspecies,0);
 	bds_force.FillBoundary(geom.periodicity());
 
-	BDS(rho_update, nspecies, SPEC_BC_COMP, rho_old, umac, bds_force, geom, dt);
+	BDS(rho_update, nspecies, SPEC_BC_COMP, rho_old, umac, bds_force, geom, dt, 2);
       
     }
     else {
@@ -429,7 +429,7 @@ void AdvanceTimestepInertial(std::array< MultiFab, AMREX_SPACEDIM >& umac,
 	}
 	rho_update.setVal(0.);
 	
-	BDS(rho_update, nspecies, SPEC_BC_COMP, rho_old, umac_tmp, bds_force, geom, dt);
+	BDS(rho_update, nspecies, SPEC_BC_COMP, rho_old, umac_tmp, bds_force, geom, dt, 2);
     }
     else {
         Abort("Invalid advection_type");

--- a/exec/multispec/inputs_2_bubbles_3d
+++ b/exec/multispec/inputs_2_bubbles_3d
@@ -36,7 +36,7 @@
   variance_coef_mass = 0.0
   initial_variance_mom = 0.
   
-  advection_type = 1
+  advection_type = 2
 
   k_B = 1.            	# [units: cm2*g*s-2*K-1]
   T_init = 1. 	# [units: K]

--- a/src_hydro/BDS.cpp
+++ b/src_hydro/BDS.cpp
@@ -129,6 +129,9 @@ void BDS_ComputeEdgeState(Box const& bx, int ncomp, int bccomp,
                          q, xedge, yedge, slopefab.array(),
                          umac, vmac, fq, l_dt);
     }
+
+    // project edge states to satisfy EOS
+    BDS_Proj(bx,ncomp,xedge,yedge);
 }
 
 /**
@@ -851,6 +854,9 @@ void BDS_ComputeEdgeState(Box const& bx, int ncomp, int bccomp,
                          umac, vmac, wmac, fq,
                          l_dt);
     }
+
+    // project edge states to satisfy EOS
+    BDS_Proj(bx,ncomp,xedge,yedge,zedge);
 }
 
 /**
@@ -4123,3 +4129,55 @@ void BDS_ComputeConc(Box const& bx,
     });
 }
 #endif
+
+// project edge states to satisfy EOS
+void BDS_Proj(Box const& bx,
+	      int ncomp,
+	      Array4<Real> const& sedgex,
+	      Array4<Real> const& sedgey
+#if (AMREX_SPACEDIM == 3)
+	      , Array4<Real> const& sedgez
+#endif
+	      )
+{
+
+   Box const& xbx = amrex::surroundingNodes(bx,0);
+   ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+
+     GpuArray<Real, MAX_SPECIES> sedge;
+     for (int n=0; n<ncomp; ++n) {
+       sedge[n] = sedgex(i,j,k,n);
+     }
+
+     //     BDS_Proj_local(sedge,ncomp);
+     
+     for (int n=0; n<ncomp; ++n) {
+       sedgex(i,j,k,n) = sedge[n];
+     }
+     
+   });
+
+   Box const& ybx = amrex::surroundingNodes(bx,1);
+   ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+
+
+   });
+
+#if (AMREX_SPACEDIM == 3)
+   Box const& zbx = amrex::surroundingNodes(bx,2);
+   ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+
+
+   });
+#endif
+
+}
+
+
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void BDS_Proj_local (GpuArray<Real,MAX_SPECIES> sedge,
+		     int ncomp)
+{
+
+}

--- a/src_hydro/hydro_functions.H
+++ b/src_hydro/hydro_functions.H
@@ -80,6 +80,16 @@ void BDS_ComputeConc(Box const& bx,
                      Array4<Real const> const& force,
                      const Real dt);
 
+// project edge states to satisfy EOS
+void BDS_Proj(Box const& bx,
+	      int ncomp,
+	      Array4<Real> const& sedgex,
+	      Array4<Real> const& sedgey
+#if (AMREX_SPACEDIM == 3)
+	      , Array4<Real> const& sedgez
+#endif
+	      );
+
 /////////////////////////////////////////////////////////////////////////////////
 // in ConvertMToUmac.cpp
 

--- a/src_hydro/hydro_functions.H
+++ b/src_hydro/hydro_functions.H
@@ -38,9 +38,12 @@ void BDS(MultiFab& s_update,
 	 std::array< MultiFab, AMREX_SPACEDIM >& umac,
 	 MultiFab const& fq,
 	 Geometry const& geom,
-	 const Real dt);
+	 const Real dt,
+         const int proj_type = 0);
 
-void BDS_ComputeEdgeState(Box const& bx, int ncomp, int bccomp,
+void BDS_ComputeEdgeState(Box const& bx,
+                          int ncomp,
+                          int bccomp,
                           Array4<Real const> const& q,
                           Array4<Real      > const& xedge,
                           Array4<Real      > const& yedge,
@@ -54,17 +57,20 @@ void BDS_ComputeEdgeState(Box const& bx, int ncomp, int bccomp,
 #endif
                           Array4<Real const> const& fq,
                           Geometry geom,
-                          Real l_dt);
+                          Real l_dt,
+                          const int proj_type);
 
 void BDS_ComputeSlopes(Box const& bx,
                        const Geometry& geom,
-                       int icomp, int bccomp,
+                       int icomp,
+                       int bccomp,
                        Array4<Real const> const& s,
                        Array4<Real      > const& slopes);
 
 void BDS_ComputeConc(Box const& bx,
                      const Geometry& geom,
-                     int icomp, int bccomp,
+                     int icomp,
+                     int bccomp,
                      Array4<Real const> const& s,
                      Array4<Real      > const& sedgex,
                      Array4<Real      > const& sedgey,
@@ -81,14 +87,50 @@ void BDS_ComputeConc(Box const& bx,
                      const Real dt);
 
 // project edge states to satisfy EOS
-void BDS_Proj(Box const& bx,
-	      int ncomp,
+void BDS_Proj(const Box& bx,
+	      const int ncomp,
 	      Array4<Real> const& sedgex,
-	      Array4<Real> const& sedgey
+	      Array4<Real> const& sedgey,
 #if (AMREX_SPACEDIM == 3)
-	      , Array4<Real> const& sedgez
+	      Array4<Real> const& sedgez,
 #endif
-	      );
+	      const int proj_type);
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void BDS_Proj_local (GpuArray<Real,MAX_SPECIES>& sedge,
+		     const int& ncomp,
+                     const int& proj_type)
+{
+
+    GpuArray<Real, MAX_SPECIES> w;
+    GpuArray<Real, MAX_SPECIES> z;
+    
+    Real rhobar_sq, delta_eos, temp;
+
+    if (proj_type == 0) {
+        
+        // do nothing
+        
+    } else if (proj_type == 2) { // L2 projection onto the linear EOS constraint for low Mach models
+
+    } else if (proj_type == 3) { // Ensure sum(rho)=rho0 for Boussinesq models
+
+        Real sumw = 0.;
+        for (int n=0; n<ncomp; ++n) {
+            w[n] = sedge[n] / rho0;
+            sumw += w[n];
+        }
+        for (int n=0; n<ncomp; ++n) {
+            sedge[n] = rho0* w[n] / sumw;
+        }
+        
+    } else if (proj_type == 4) { // Ensure sum(rho)=rho0
+
+    } else {
+        Abort("BDS_Proj: invalid proj_type");
+    }
+
+}
 
 /////////////////////////////////////////////////////////////////////////////////
 // in ConvertMToUmac.cpp

--- a/src_hydro/hydro_functions.H
+++ b/src_hydro/hydro_functions.H
@@ -113,6 +113,36 @@ void BDS_Proj_local (GpuArray<Real,MAX_SPECIES>& sedge,
         
     } else if (proj_type == 2) { // L2 projection onto the linear EOS constraint for low Mach models
 
+        Abort("Code up and test BDS_Proj proj_type=2");
+        
+#if 0
+       ! compute mass fractions, w_i = rho_i / rho
+       temp = 0.d0
+       do comp=1,ncomp
+          temp = temp + sedge(comp)
+       end do
+       do comp=1,ncomp
+          w(comp) = sedge(comp)/temp
+       end do
+
+       ! rhobar_sq = (sum_i (w_i/rhobar_i^2))^-1
+       rhobar_sq = 0.d0
+       do comp=1,ncomp
+          rhobar_sq = rhobar_sq + w(comp)/rhobar(comp)**2
+       end do
+       rhobar_sq = 1.d0/rhobar_sq
+
+       ! delta_eos = sum_l (rho_l/rhobar_l) - 1
+       delta_eos = -1.d0
+       do comp=1,ncomp
+          delta_eos = delta_eos + sedge(comp)/rhobar(comp)
+       end do
+
+       do comp=1,ncomp
+          sedge(comp) = sedge(comp) - w(comp)*(rhobar_sq/rhobar(comp))*delta_eos
+       end do
+#endif
+        
     } else if (proj_type == 3) { // Ensure sum(rho)=rho0 for Boussinesq models
 
         Real sumw = 0.;
@@ -126,6 +156,21 @@ void BDS_Proj_local (GpuArray<Real,MAX_SPECIES>& sedge,
         
     } else if (proj_type == 4) { // Ensure sum(rho)=rho0
 
+        Abort("Code up and test BDS_Proj proj_type=4");
+
+#if 0
+       ! and also sum(z*rho)=0 for electroneutral Boussinesq models
+
+       ! Ensure sum(z*rho)=0
+       z = charge_per_mass(1:ncomp)
+       sedge = sedge - sum(sedge*z) / sum(z*z) * z
+
+       ! Now ensure sum(rho)=rho0 while preserving sum(z*rho)=0
+       w = sedge/rho0 ! Mass fractions
+       sedge = rho0 * (w/sum(w))
+       !write(*,*) "z^T*rho=", sum(sedge*z), " 1^T*w-1=", sum(sedge/rho0)-1.0d0
+#endif
+                                                       
     } else {
         Abort("BDS_Proj: invalid proj_type");
     }


### PR DESCRIPTION
Ensure that the BDS edge states satisfy the constraint.
Boussinesq variant coded up; inertial will come later when someone tries to invoke it (with an error and fortran code to be converted).