### PR TITLE
Max element

### DIFF
--- a/exec/multispec/GNUmakefile
+++ b/exec/multispec/GNUmakefile
@@ -10,6 +10,8 @@ COMP      = gnu
 DIM       = 2
 DSMC      = FALSE
 MAX_SPEC      = 8
+# MAX_ELEM needs to be MAX_SPEC*(MAX_SPEC-1)/2
+MAX_ELEM      = 28
 
 TINY_PROFILE = TRUE
 USE_PARTICLES = FALSE
@@ -63,4 +65,7 @@ endif
 
 MAXSPECIES := $(strip $(MAX_SPEC))
 DEFINES += -DMAX_SPECIES=$(MAXSPECIES)
+
+MAXELEMENT := $(strip $(MAX_ELEM))
+DEFINES += -DMAX_ELEMENT=$(MAXELEMENT)
 

--- a/src_common/common_namespace.H
+++ b/src_common/common_namespace.H
@@ -1,11 +1,9 @@
 namespace common {
 
 //////////////
-// #define MAX_SPECIES 8
 #define ADJ 0.99999
 #define ADJALT 0.00002
 #define WRITE_BUFFER 1000
-#define MAX_ELEMENT 28 // needs to be MAX_SPECIES*(MAX_SPECIES-1)/2
 #define MAX_BONDS 12
 //////////////
     

--- a/src_multispec/multispec_functions.cpp
+++ b/src_multispec/multispec_functions.cpp
@@ -57,6 +57,10 @@ amrex::Real                                                 multispec::L_zero;
 
 void InitializeMultispecNamespace() {
 
+    if (MAX_ELEMENT != (MAX_SPECIES*MAX_SPECIES-1)/2) {
+        Abort("MAX_ELEMENT != (MAX_SPECIES*MAX_SPECIES-1)/2)");
+    }
+    
     E_ext_value.resize(AMREX_SPACEDIM);
 
     // specify default values first, then read in values from inputs file

--- a/src_multispec/multispec_functions.cpp
+++ b/src_multispec/multispec_functions.cpp
@@ -57,7 +57,9 @@ amrex::Real                                                 multispec::L_zero;
 
 void InitializeMultispecNamespace() {
 
-    if (MAX_ELEMENT != (MAX_SPECIES*MAX_SPECIES-1)/2) {
+    if (MAX_ELEMENT != MAX_SPECIES*(MAX_SPECIES-1)/2) {
+        Print() << "MAX_ELEMENT " << MAX_ELEMENT << std::endl;
+        Print() << "MAX_SPECIES " << MAX_SPECIES << std::endl;
         Abort("MAX_ELEMENT != (MAX_SPECIES*MAX_SPECIES-1)/2)");
     }
     


### PR DESCRIPTION
Now define MAX_ELEMENT as a compile-time parameter instead of hard-coded.
Must be equal to MAX_SPECIES*(MAX_SPECIES-1)/2 or it will abort.
Default value is 28