### PR TITLE
Added support for bulk viscosity in staggered compressible FHD

### DIFF
--- a/src_compressible/compressible_functions.cpp
+++ b/src_compressible/compressible_functions.cpp
@@ -9,6 +9,7 @@ AMREX_GPU_MANAGED int compressible::do_2D;
 AMREX_GPU_MANAGED int compressible::all_correl;
 AMREX_GPU_MANAGED int compressible::nspec_surfcov = 0;
 AMREX_GPU_MANAGED bool compressible::do_reservoir = false;
+AMREX_GPU_MANAGED amrex::Real compressible::zeta_ratio = -1.0;
 
 void InitializeCompressibleNamespace()
 {
@@ -69,6 +70,11 @@ void InitializeCompressibleNamespace()
         (bc_mass_hi[0] == 4) or (bc_mass_hi[1] == 4) or (bc_mass_hi[2] == 4)) {
         do_reservoir = true;
     }
+
+    // bulk viscosity ratio
+    pp.query("zeta_ratio",zeta_ratio);
+    if ((amrex::Math::abs(visc_type) == 3) and (zeta_ratio < 0.0)) amrex::Abort("need non-negative zeta_ratio (ratio of bulk to shear viscosity) for visc_type = 3 (use bulk viscosity)");
+    if ((amrex::Math::abs(visc_type) == 3) and (zeta_ratio >= 0.0)) amrex::Print() << "bulk viscosity model selected; bulk viscosity ratio is: " << zeta_ratio << "\n";
 
     return;
 }

--- a/src_compressible/compressible_namespace.H
+++ b/src_compressible/compressible_namespace.H
@@ -8,6 +8,7 @@ namespace compressible {
     extern AMREX_GPU_MANAGED int all_correl;
     extern AMREX_GPU_MANAGED int nspec_surfcov;
     extern AMREX_GPU_MANAGED bool do_reservoir;
+    extern AMREX_GPU_MANAGED amrex::Real zeta_ratio;
 
 }
 

--- a/src_compressible/transCoeffs.cpp
+++ b/src_compressible/transCoeffs.cpp
@@ -75,6 +75,12 @@ void calculateTransportCoeffs(const MultiFab& prim_in,
                 }
             }
 
+            // set bulk viscosity
+            if (amrex::Math::abs(visc_type) == 3) {
+                zeta(i,j,k) = zeta_ratio * eta(i,j,k);
+            }
+
+
         });
     }
 }

--- a/src_compressible_stag/compressible_functions_stag.H
+++ b/src_compressible_stag/compressible_functions_stag.H
@@ -32,7 +32,8 @@ void WritePlotFileStag(int step,
                        const MultiFab& surfcovMeans,
                        const MultiFab& surfcovVars,
                        const MultiFab& eta, 
-                       const MultiFab& kappa);
+                       const MultiFab& kappa,
+                       const MultiFab& zeta);
 
 void WriteSpatialCross3D(const Vector<Real>& spatialCross, int step, const Geometry& geom, const int ncross);
 

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -717,7 +717,7 @@ void main_driver(const char* argv)
         
         if (plot_int > 0) {
             WritePlotFileStag(0, 0.0, geom, cu, cuMeans, cuVars, cumom, cumomMeans, cumomVars, 
-                          prim, primMeans, primVars, vel, velMeans, velVars, coVars, surfcov, surfcovMeans, surfcovVars, eta, kappa);
+                          prim, primMeans, primVars, vel, velMeans, velVars, coVars, surfcov, surfcovMeans, surfcovVars, eta, kappa, zeta);
 #if defined(TURB)
             if (turbForcing > 0) {
                 EvaluateWritePlotFileVelGrad(0, 0.0, geom, vel, vel_decomp);
@@ -1145,7 +1145,7 @@ void main_driver(const char* argv)
             //yzAverage(cuMeans, cuVars, primMeans, primVars, spatialCross,
             //          cuMeansAv, cuVarsAv, primMeansAv, primVarsAv, spatialCrossAv);
             WritePlotFileStag(step, time, geom, cu, cuMeans, cuVars, cumom, cumomMeans, cumomVars,
-                              prim, primMeans, primVars, vel, velMeans, velVars, coVars, surfcov, surfcovMeans, surfcovVars, eta, kappa);
+                              prim, primMeans, primVars, vel, velMeans, velVars, coVars, surfcov, surfcovMeans, surfcovVars, eta, kappa, zeta);
             
 #if defined(TURB)
             if (turbForcing > 0) {

--- a/src_compressible_stag/writePlotFileStag.cpp
+++ b/src_compressible_stag/writePlotFileStag.cpp
@@ -24,7 +24,8 @@ void WritePlotFileStag(int step,
                        const amrex::MultiFab& surfcovMeans,
                        const amrex::MultiFab& surfcovVars,
                        const amrex::MultiFab& eta,
-                       const amrex::MultiFab& kappa)
+                       const amrex::MultiFab& kappa,
+                       const amrex::MultiFab& zeta)
 {
     BL_PROFILE_VAR("writePlotFileStag()",writePlotFileStag);
     
@@ -38,11 +39,13 @@ void WritePlotFileStag(int step,
     // prim: [vx, vy, vz, T, p, Yk, Xk] -- 5 + 2*nspecies
     // shifted [vx, vy, vz] -- 3
     // eta, kappa -- 2
+    // zeta -- 1 (only when visc_type = 3)
     nplot += nvars;
     nplot += 3;
     nplot += 5 + 2*nspecies;
     nplot += 3;
     nplot += 2;
+    if (amrex::Math::abs(visc_type) == 3) nplot += 1;
 
     if (nspec_surfcov>0) nplot += nspec_surfcov;
 
@@ -131,6 +134,14 @@ void WritePlotFileStag(int step,
     numvars = 1;
     amrex::MultiFab::Copy(plotfile,kappa,0,cnt,numvars,0);
     cnt+=numvars;
+
+    // instantaneous
+    // zeta -- 1
+    if (amrex::Math::abs(visc_type) == 3) {
+        numvars = 1;
+        amrex::MultiFab::Copy(plotfile,zeta,0,cnt,numvars,0);
+        cnt+=numvars;
+    }
 
     // instantaneous
     // surfcov -- nspec_surfcov
@@ -277,6 +288,7 @@ void WritePlotFileStag(int step,
 
     varNames[cnt++] = "eta";
     varNames[cnt++] = "kappa";
+    if (amrex::Math::abs(visc_type) == 3) varNames[cnt++] = "zeta";
 
     if (nspec_surfcov>0) {
         x = "surfcov_";


### PR DESCRIPTION
This PR adds support to specify the bulk viscosity contribution to the stress tensor (both stochastic and diffusive). This is enabled by specifying `visc_type = 3` and then defining a `zeta_ratio`, which sets the bulk viscsoity `zeta = zeta_ratio*eta`, where eta is the shear viscosity. This is done on a cell-by-cell basis.