### PR TITLE
MFsurfchem - change number density to pressure

### DIFF
--- a/exec/compressible_stag/test_MFsurfchem_COAr_eq/inputs_fhd_stag
+++ b/exec/compressible_stag/test_MFsurfchem_COAr_eq/inputs_fhd_stag
@@ -122,7 +122,7 @@ surf_site_num_dens = 1.027285e+15
 
 # adsorption rate = ads_rate_const * num_dens
 # desoprtion rate = des_rate
-ads_rate_const = 1.770226e-11
+ads_rate_const = 1.831671e+02
 des_rate = 3.702336e+07
 
 # e_beta = 0    # no additional energy update

--- a/exec/compressible_stag/test_MFsurfchem_COAr_eq/params_COAr_eq.py
+++ b/exec/compressible_stag/test_MFsurfchem_COAr_eq/params_COAr_eq.py
@@ -152,7 +152,7 @@ rcol1 = math.sqrt(kB*temp/2/math.pi/m1)*n1*(lat_const**2)
 
 sprob = 1.
 rads1 = sprob*rcol1
-kads1 = rads1/n1
+kads1 = rads1/p1
 
 kdes1 = rads1*math.exp((-delta_mu1+E_bind)*eV_cgs/(kB*temp))
 
@@ -162,7 +162,7 @@ print("- collision rate rcol1 = %e" % rcol1)
 
 print("- sticking prob = %f" % sprob)
 print("- rads1 = %e (rate)" % rads1)
-print("- kads1 = rads1/n1 (rate const) = %e" % kads1)
+print("- kads1 = rads1/p1 (rate const) = %e" % kads1)
 
 print("- kdes1 = %e" % kdes1)
 

--- a/src_MFsurfchem/MFsurfchem_functions.cpp
+++ b/src_MFsurfchem/MFsurfchem_functions.cpp
@@ -158,7 +158,7 @@ void sample_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab
 
                     amrex::Real theta = surfcov_arr(i,j,k,m);
 
-  		    amrex::Real meanNads = ads_rate_const[m]*dens*(1-sumtheta)*Ntot*dt*pow(tempratio,k_beta);
+  		    amrex::Real meanNads = ads_rate_const[m]*pres*(1-sumtheta)*Ntot*dt*pow(tempratio,k_beta);
                     amrex::Real meanNdes = des_rate[m]*theta*Ntot*dt;
 
                     amrex::Real Nads;

--- a/src_MFsurfchem/MFsurfchem_functions.cpp
+++ b/src_MFsurfchem/MFsurfchem_functions.cpp
@@ -153,8 +153,8 @@ void sample_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab
                 amrex:: Real tempratio = prim_arr(i,j,k,4)/T_init[0];
 
                 for (int m=0;m<n_ads_spec;m++) {
-                    amrex::Real dens = prim_arr(i,j,k,5);   // total pressure
-                    dens *= prim_arr(i,j,k,6+nspecies+m);   // partial pressure
+                    amrex::Real pres = prim_arr(i,j,k,5);   // total pressure
+                    pres *= prim_arr(i,j,k,6+nspecies+m);   // partial pressure
 
                     amrex::Real theta = surfcov_arr(i,j,k,m);
 

--- a/src_MFsurfchem/MFsurfchem_functions.cpp
+++ b/src_MFsurfchem/MFsurfchem_functions.cpp
@@ -66,7 +66,7 @@ void InitializeMFSurfchemNamespace()
     stoch_MFsurfchem = 1; // default value
     pp.query("stoch_MFsurfchem",stoch_MFsurfchem);
 
-    k_beta = 0.5; // default value
+    k_beta = -0.5; // default value
     pp.query("k_beta",k_beta);
 
     e_beta = 0.5; // default value
@@ -153,8 +153,8 @@ void sample_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab
                 amrex:: Real tempratio = prim_arr(i,j,k,4)/T_init[0];
 
                 for (int m=0;m<n_ads_spec;m++) {
-                    amrex::Real dens = cu_arr(i,j,k,5+m);   // mass density
-                    dens *= AVONUM/molmass[m];              // number density
+                    amrex::Real dens = prim_arr(i,j,k,5);   // total pressure
+                    dens *= prim_arr(i,j,k,6+nspecies+m);   // partial pressure
 
                     amrex::Real theta = surfcov_arr(i,j,k,m);
 


### PR DESCRIPTION
PR to review the revised scheme for MFsurfchem. (original) number density  to (revised) pressure
1. src_MFsurfchem
- Default value of k_beta = -1/2
- Variable "dens" = partial pressure

2. test_MFsurfchem_COAr_eq
- ads_rate_const in "inputs_fhd_stag" and kads1 in "params_COAr_eq.py"