### PR TITLE
Implement slice structure factor for compressible_stag

### DIFF
--- a/src_common/ComputeAverages.cpp
+++ b/src_common/ComputeAverages.cpp
@@ -408,19 +408,19 @@ void ExtractSlice(const MultiFab& mf, MultiFab& mf_slice,
         if (dir == 0) {
             amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
             {
-                slice(0,j,k) = slice_tmp(i,j,k);
+                slice(0,j,k,n) = slice_tmp(i,j,k,n);
             });
         }
         if (dir == 1) {
             amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
             {
-                slice(i,0,k) = slice_tmp(i,j,k);
+                slice(i,0,k,n) = slice_tmp(i,j,k,n);
             });
         }
         if (dir == 2) {
             amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
             {
-                slice(i,j,0) = slice_tmp(i,j,k);
+                slice(i,j,0,n) = slice_tmp(i,j,k,n);
             });
         }
     }

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -208,8 +208,13 @@ void main_driver(const char* argv)
     if ((plot_cross) and ((cross_cell < 0) or (cross_cell > n_cells[0]-1))) {
         Abort("Cross cell needs to be within the domain: 0 <= cross_cell <= n_cells[0] - 1");
     }
-    if ((do_slab_sf) and ((membrane_cell <= 0) or (membrane_cell >= n_cells[0]-1))) {
-        Abort("Slab structure factor needs a membrane cell within the domain: 0 < cross_cell < n_cells[0] - 1");
+    if (project_dir >= 0) {
+        if (do_slab_sf and ((membrane_cell <= 0) or (membrane_cell >= n_cells[project_dir]-1))) {
+            Abort("Slab structure factor needs a membrane cell within the domain: 0 < cross_cell < n_cells[project_dir] - 1");
+        }
+        if (do_slab_sf and slicepoint >= 0) {
+            Abort("Cannot use do_slab_sf and slicepoint");
+        }
     }
     if ((project_dir >= 0) and ((do_1D) or (do_2D))) {
         Abort("Projected structure factors (project_dir) works only for 3D case");
@@ -276,9 +281,9 @@ void main_driver(const char* argv)
     MultiFab structFactPrimMF;
     MultiFab structFactConsMF;
 
-    // Structure factor for 2D averaged data
-    StructFact structFactPrimVerticalAverage;
-    StructFact structFactConsVerticalAverage;
+    // Structure factor for vertically-averaged or sliced data
+    StructFact structFactPrimFlattened;
+    StructFact structFactConsFlattened;
 
     // Structure factor for 2D averaged data (across a membrane)
     StructFact structFactPrimVerticalAverage0;
@@ -781,7 +786,11 @@ void main_driver(const char* argv)
 
             {
                 MultiFab X, XRot;
-                ComputeVerticalAverage(prim, X, geom, project_dir, 0, nprimvars);
+                if (slicepoint < 0) {
+                    ComputeVerticalAverage(prim, X, geom, project_dir, 0, nprimvars);
+                } else {
+                    ExtractSlice(prim, X, geom, project_dir, slicepoint, 0, 1);
+                }
                 XRot = RotateFlattenedMF(X);
                 ba_flat = XRot.boxArray();
                 dmap_flat = XRot.DistributionMap();
@@ -845,8 +854,8 @@ void main_driver(const char* argv)
             }
 
             if (do_slab_sf == 0) {
-                structFactPrimVerticalAverage.define(ba_flat,dmap_flat,prim_var_names,var_scaling_prim,2);
-                structFactConsVerticalAverage.define(ba_flat,dmap_flat,cons_var_names,var_scaling_cons,2);
+                structFactPrimFlattened.define(ba_flat,dmap_flat,prim_var_names,var_scaling_prim);
+                structFactConsFlattened.define(ba_flat,dmap_flat,cons_var_names,var_scaling_cons);
             }
             else {
                 structFactPrimVerticalAverage0.define(ba_flat,dmap_flat,prim_var_names,var_scaling_prim);
@@ -1468,19 +1477,27 @@ void main_driver(const char* argv)
                     {
                         MultiFab X, XRot;
 
-                        ComputeVerticalAverage(structFactPrimMF, X, geom, project_dir, 0, structVarsPrim);
+                        if (slicepoint < 0) {
+                            ComputeVerticalAverage(structFactPrimMF, X, geom, project_dir, 0, structVarsPrim);
+                        } else {
+                            ExtractSlice(structFactPrimMF, X, geom, project_dir, slicepoint, 0, structVarsPrim);
+                        }
                         XRot = RotateFlattenedMF(X);
                         master_project_rot_prim.ParallelCopy(XRot, 0, 0, structVarsPrim); 
-                        structFactPrimVerticalAverage.FortStructure(master_project_rot_prim,geom_flat);
+                        structFactPrimFlattened.FortStructure(master_project_rot_prim,geom_flat);
                     }
 
                     {
                         MultiFab X, XRot;
 
-                        ComputeVerticalAverage(structFactConsMF, X, geom, project_dir, 0, structVarsCons);
+                        if (slicepoint < 0) {
+                            ComputeVerticalAverage(structFactConsMF, X, geom, project_dir, 0, structVarsCons);
+                        } else {
+                            ExtractSlice(structFactConsMF, X, geom, project_dir, slicepoint, 0, structVarsCons);
+                        }
                         XRot = RotateFlattenedMF(X);
                         master_project_rot_cons.ParallelCopy(XRot, 0, 0, structVarsCons);
-                        structFactConsVerticalAverage.FortStructure(master_project_rot_cons,geom_flat);
+                        structFactConsFlattened.FortStructure(master_project_rot_cons,geom_flat);
                     }
 
                 }
@@ -1576,8 +1593,8 @@ void main_driver(const char* argv)
 
             if (project_dir >= 0) {
                 if (do_slab_sf == 0) {
-                    structFactPrimVerticalAverage.WritePlotFile(step,time,geom_flat,"plt_SF_prim_VerticalAverage");
-                    structFactConsVerticalAverage.WritePlotFile(step,time,geom_flat,"plt_SF_cons_VerticalAverage");
+                    structFactPrimFlattened.WritePlotFile(step,time,geom_flat,"plt_SF_prim_Flattened");
+                    structFactConsFlattened.WritePlotFile(step,time,geom_flat,"plt_SF_cons_Flattened");
                 }
                 else {
                     structFactPrimVerticalAverage0.WritePlotFile(step,time,geom_flat,"plt_SF_prim_VerticalAverageSlab0");


### PR DESCRIPTION
Implement slice structure factor for compressible_stag
    
To use, set project_dir (normal direction of plane) and slicepoint (coordinate in project_dir to slice) in the inputs file; e.g. if you care about the k=0 plane use project_dir=2 and slicepoint=0
    
If you do not specify slicepoint it will take the vertical average over project_dir over the entire dataset
    
plt_SF_prim_Flattened plt_SF_cons_Flattened contains the result