### PR TITLE
Fix inputs_giantfluct_3d to work by ensuring bc YK's sum to 1

### DIFF
--- a/exec/compressible/inputs_giantfluct_3d
+++ b/exec/compressible/inputs_giantfluct_3d
@@ -98,7 +98,7 @@
 
   # Xk and Yk at the wall for Dirichlet (concentrations) - set one to zero
   # Ordering: (species 1, x-dir), (species 2, x-dir), ... (species 1, y-dir), ...
-  bc_Yk_y_lo = 0.2 0.09316672 0.70683296     # lo BC
-  bc_Yk_y_hi = 0.3 0.40683328 0.29316704     # hi BC
+  bc_Yk_y_lo = 0.2 0.09316672 0.70683328     # lo BC
+  bc_Yk_y_hi = 0.3 0.40683328 0.29316672     # hi BC
 
 

--- a/src_compressible_stag/boundaryStag.cpp
+++ b/src_compressible_stag/boundaryStag.cpp
@@ -32,6 +32,9 @@ void SetupCWallStag() {
        } else if (amrex::Math::abs(sumy-1) < 1.e-10) {
            GetMolfrac(bc_Yk_x_lo,bc_Xk_x_lo);
        }
+       else {
+           Abort("SetupCWallStag: lo-x; mass or mole fractions do not sum to 1");
+       }
     }
 
     if (bc_mass_lo[0] >= 3) {
@@ -69,6 +72,8 @@ void SetupCWallStag() {
           GetMassfrac(bc_Xk_x_hi,bc_Yk_x_hi);
        } else if (amrex::Math::abs(sumy-1) < 1.e-10) {
           GetMolfrac(bc_Yk_x_hi,bc_Xk_x_hi);
+       } else {
+           Abort("SetupCWallStag: hi-x; mass or mole fractions do not sum to 1");
        }
     }
 
@@ -108,6 +113,8 @@ void SetupCWallStag() {
           GetMassfrac(bc_Xk_y_lo,bc_Yk_y_lo);
        } else if (amrex::Math::abs(sumy-1) < 1.e-10) {
           GetMolfrac(bc_Yk_y_lo,bc_Xk_y_lo);
+       } else {
+           Abort("SetupCWallStag: lo-y; mass or mole fractions do not sum to 1");
        }
     }
 
@@ -146,6 +153,8 @@ void SetupCWallStag() {
           GetMassfrac(bc_Xk_y_hi,bc_Yk_y_hi);
        } else if (amrex::Math::abs(sumy-1) < 1.e-10) {
           GetMolfrac(bc_Yk_y_hi,bc_Xk_y_hi);
+       } else {
+           Abort("SetupCWallStag: hi-y; mass or mole fractions do not sum to 1");
        }
     }
 
@@ -185,6 +194,8 @@ void SetupCWallStag() {
           GetMassfrac(bc_Xk_z_lo,bc_Yk_z_lo);
        } else if (amrex::Math::abs(sumy-1) < 1.e-10) {
           GetMolfrac(bc_Yk_z_lo,bc_Xk_z_lo);
+       } else {
+           Abort("SetupCWallStag: lo-z; mass or mole fractions do not sum to 1");
        }
     }
 
@@ -223,6 +234,8 @@ void SetupCWallStag() {
           GetMassfrac(bc_Xk_z_hi,bc_Yk_z_hi);
        } else if (amrex::Math::abs(sumy-1) < 1.e-10) {
           GetMolfrac(bc_Yk_z_hi,bc_Xk_z_hi);
+       } else {
+           Abort("SetupCWallStag: hi-z; mass or mole fractions do not sum to 1");
        }
     }
 


### PR DESCRIPTION
fix inputs_giantflux_3d to work by ensuring bc YK's sum to 1
add error checking for this condition in the compressible_stag code

This example only runs in the compressible_stag framework at present.  The cell-centered run aborts since the n_cells_z=1 case for stoch flux is not supported yet.