### PR TITLE
Average cleanup

### DIFF
--- a/exec/compressible_mui/sav_src/2020/m00.cpp
+++ b/exec/compressible_mui/sav_src/2020/m00.cpp
@@ -521,7 +521,7 @@ void main_driver(const char* argv)
 
     if(project_dir >= 0){
       prim.setVal(0.0);
-      ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+      ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
       BoxArray ba_flat = primVertAvg.boxArray();
       const DistributionMapping& dmap_flat = primVertAvg.DistributionMap();
       {
@@ -675,7 +675,7 @@ void main_driver(const char* argv)
            structFactPrim.FortStructure(structFactPrimMF);
            structFactCons.FortStructure(structFactConsMF);
            if(project_dir >= 0) {
-                ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+                ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
                 structFactPrimVerticalAverage.FortStructure(primVertAvg);
            }
         }

--- a/exec/compressible_mui/sav_src/2020/m01-cutemp_jsq.cpp
+++ b/exec/compressible_mui/sav_src/2020/m01-cutemp_jsq.cpp
@@ -533,7 +533,7 @@ void main_driver(const char* argv)
 
     if(project_dir >= 0){
       prim.setVal(0.0);
-      ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+      ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
       BoxArray ba_flat = primVertAvg.boxArray();
       const DistributionMapping& dmap_flat = primVertAvg.DistributionMap();
       {
@@ -687,7 +687,7 @@ void main_driver(const char* argv)
            structFactPrim.FortStructure(structFactPrimMF);
            structFactCons.FortStructure(structFactConsMF);
            if(project_dir >= 0) {
-                ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+                ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
                 structFactPrimVerticalAverage.FortStructure(primVertAvg);
            }
         }

--- a/exec/compressible_mui/sav_src/2020/m01.cpp
+++ b/exec/compressible_mui/sav_src/2020/m01.cpp
@@ -521,7 +521,7 @@ void main_driver(const char* argv)
 
     if(project_dir >= 0){
       prim.setVal(0.0);
-      ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+      ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
       BoxArray ba_flat = primVertAvg.boxArray();
       const DistributionMapping& dmap_flat = primVertAvg.DistributionMap();
       {
@@ -675,7 +675,7 @@ void main_driver(const char* argv)
            structFactPrim.FortStructure(structFactPrimMF);
            structFactCons.FortStructure(structFactConsMF);
            if(project_dir >= 0) {
-                ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+                ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
                 structFactPrimVerticalAverage.FortStructure(primVertAvg);
            }
         }

--- a/exec/compressible_mui/sav_src/2020/m02.cpp
+++ b/exec/compressible_mui/sav_src/2020/m02.cpp
@@ -574,7 +574,7 @@ void main_driver(const char* argv)
 
     if(project_dir >= 0){
       prim.setVal(0.0);
-      ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+      ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
       BoxArray ba_flat = primVertAvg.boxArray();
       const DistributionMapping& dmap_flat = primVertAvg.DistributionMap();
       {
@@ -728,7 +728,7 @@ void main_driver(const char* argv)
            structFactPrim.FortStructure(structFactPrimMF);
            structFactCons.FortStructure(structFactConsMF);
            if(project_dir >= 0) {
-                ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+                ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
                 structFactPrimVerticalAverage.FortStructure(primVertAvg);
            }
         }

--- a/exec/compressible_mui/sav_src/2020/m10.cpp
+++ b/exec/compressible_mui/sav_src/2020/m10.cpp
@@ -523,7 +523,7 @@ void main_driver(const char* argv)
 
     if(project_dir >= 0){
       prim.setVal(0.0);
-      ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+      ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
       BoxArray ba_flat = primVertAvg.boxArray();
       const DistributionMapping& dmap_flat = primVertAvg.DistributionMap();
       {
@@ -684,7 +684,7 @@ void main_driver(const char* argv)
            structFactPrim.FortStructure(structFactPrimMF);
            structFactCons.FortStructure(structFactConsMF);
            if(project_dir >= 0) {
-                ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+                ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
                 structFactPrimVerticalAverage.FortStructure(primVertAvg);
            }
         }

--- a/exec/compressible_mui/sav_src/2020/m11.cpp
+++ b/exec/compressible_mui/sav_src/2020/m11.cpp
@@ -527,7 +527,7 @@ void main_driver(const char* argv)
 
     if(project_dir >= 0){
       prim.setVal(0.0);
-      ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+      ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
       BoxArray ba_flat = primVertAvg.boxArray();
       const DistributionMapping& dmap_flat = primVertAvg.DistributionMap();
       {
@@ -688,7 +688,7 @@ void main_driver(const char* argv)
            structFactPrim.FortStructure(structFactPrimMF);
            structFactCons.FortStructure(structFactConsMF);
            if(project_dir >= 0) {
-                ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+                ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
                 structFactPrimVerticalAverage.FortStructure(primVertAvg);
            }
         }

--- a/exec/compressible_mui/sav_src/2020/m12.cpp
+++ b/exec/compressible_mui/sav_src/2020/m12.cpp
@@ -527,7 +527,7 @@ void main_driver(const char* argv)
 
     if(project_dir >= 0){
       prim.setVal(0.0);
-      ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+      ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
       BoxArray ba_flat = primVertAvg.boxArray();
       const DistributionMapping& dmap_flat = primVertAvg.DistributionMap();
       {
@@ -690,7 +690,7 @@ void main_driver(const char* argv)
            structFactPrim.FortStructure(structFactPrimMF);
            structFactCons.FortStructure(structFactConsMF);
            if(project_dir >= 0) {
-                ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+                ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
                 structFactPrimVerticalAverage.FortStructure(primVertAvg);
            }
         }

--- a/exec/compressible_mui/sav_src/202101_before_mui_span/main_driver.cpp
+++ b/exec/compressible_mui/sav_src/202101_before_mui_span/main_driver.cpp
@@ -534,7 +534,7 @@ void main_driver(const char* argv)
 
     if(project_dir >= 0){
       prim.setVal(0.0);
-      ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+      ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
       BoxArray ba_flat = primVertAvg.boxArray();
       const DistributionMapping& dmap_flat = primVertAvg.DistributionMap();
       {
@@ -703,7 +703,7 @@ void main_driver(const char* argv)
            structFactPrim.FortStructure(structFactPrimMF);
            structFactCons.FortStructure(structFactConsMF);
            if(project_dir >= 0) {
-                ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+                ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
                 structFactPrimVerticalAverage.FortStructure(primVertAvg);
            }
         }

--- a/exec/compressible_mui/sav_src/202101_before_mui_span/main_driver.cpp_0126_bc
+++ b/exec/compressible_mui/sav_src/202101_before_mui_span/main_driver.cpp_0126_bc
@@ -547,7 +547,7 @@ void main_driver(const char* argv)
 
     if(project_dir >= 0){
       prim.setVal(0.0);
-      ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+      ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
       BoxArray ba_flat = primVertAvg.boxArray();
       const DistributionMapping& dmap_flat = primVertAvg.DistributionMap();
       {
@@ -716,7 +716,7 @@ void main_driver(const char* argv)
            structFactPrim.FortStructure(structFactPrimMF);
            structFactCons.FortStructure(structFactConsMF);
            if(project_dir >= 0) {
-                ComputeVerticalAverage(prim, primVertAvg, geom, project_dir, 0, structVarsPrim);
+                ComputeVerticalAverage(prim, primVertAvg, project_dir, 0, structVarsPrim);
                 structFactPrimVerticalAverage.FortStructure(primVertAvg);
            }
         }

--- a/exec/compressible_mui/sav_src/202106_before_summer/main_driver.cpp
+++ b/exec/compressible_mui/sav_src/202106_before_summer/main_driver.cpp
@@ -514,9 +514,9 @@ void main_driver(const char* argv)
       // a built version of primFlattened so can obtain what we need to build the
       // structure factor and geometry objects for flattened data
       if (slicepoint < 0) {
-          ComputeVerticalAverage(prim, primFlattened, geom, project_dir, 0, structVarsPrim);
+          ComputeVerticalAverage(prim, primFlattened, project_dir, 0, structVarsPrim);
       } else {
-          ExtractSlice(prim, primFlattened, geom, project_dir, slicepoint, 0, structVarsPrim);
+          ExtractSlice(prim, primFlattened, project_dir, slicepoint, 0, structVarsPrim);
       }
       // we rotate this flattened MultiFab to have normal in the z-direction since
       // SWFFT only presently supports flattened MultiFabs with z-normal.
@@ -857,9 +857,9 @@ void main_driver(const char* argv)
             if(project_dir >= 0) {
                 MultiFab primFlattened;  // flattened multifab defined below
                 if (slicepoint < 0) {
-                    ComputeVerticalAverage(prim, primFlattened, geom, project_dir, 0, structVarsPrim);
+                    ComputeVerticalAverage(prim, primFlattened, project_dir, 0, structVarsPrim);
                 } else {
-                    ExtractSlice(prim, primFlattened, geom, project_dir, slicepoint, 0, structVarsPrim);
+                    ExtractSlice(prim, primFlattened, project_dir, slicepoint, 0, structVarsPrim);
                 }
                 // we rotate this flattened MultiFab to have normal in the z-direction since
                 // SWFFT only presently supports flattened MultiFabs with z-normal.

--- a/exec/hydro/main_driver.cpp
+++ b/exec/hydro/main_driver.cpp
@@ -360,9 +360,9 @@ void main_driver(const char* argv)
       // a built version of Flattened so can obtain what we need to build the
       // structure factor and geometry objects for flattened data
       if (slicepoint < 0) {
-          ComputeVerticalAverage(structFactMF, Flattened, geom, project_dir, 0, 1);
+          ComputeVerticalAverage(structFactMF, Flattened, project_dir, 0, 1);
       } else {
-          ExtractSlice(structFactMF, Flattened, geom, project_dir, slicepoint, 0, 1);
+          ExtractSlice(structFactMF, Flattened, project_dir, slicepoint, 0, 1);
       }
       BoxArray ba_flat = Flattened.boxArray();
       const DistributionMapping& dmap_flat = Flattened.DistributionMap();
@@ -432,9 +432,9 @@ void main_driver(const char* argv)
             if(project_dir >= 0) {
                 MultiFab Flattened;  // flattened multifab defined below
                 if (slicepoint < 0) {
-                    ComputeVerticalAverage(structFactMF, Flattened, geom, project_dir, 0, structVars);
+                    ComputeVerticalAverage(structFactMF, Flattened, project_dir, 0, structVars);
                 } else {
-                    ExtractSlice(structFactMF, Flattened, geom, project_dir, slicepoint, 0, structVars);
+                    ExtractSlice(structFactMF, Flattened, project_dir, slicepoint, 0, structVars);
                 }
                 structFactFlattened.FortStructure(Flattened);
             }
@@ -526,9 +526,9 @@ void main_driver(const char* argv)
             if(project_dir >= 0) {
                 MultiFab Flattened;  // flattened multifab defined below
                 if (slicepoint < 0) {
-                    ComputeVerticalAverage(structFactMF, Flattened, geom, project_dir, 0, structVars);
+                    ComputeVerticalAverage(structFactMF, Flattened, project_dir, 0, structVars);
                 } else {
-                    ExtractSlice(structFactMF, Flattened, geom, project_dir, slicepoint, 0, structVars);
+                    ExtractSlice(structFactMF, Flattened, project_dir, slicepoint, 0, structVars);
                 }
                 structFactFlattened.FortStructure(Flattened);
             }

--- a/src_common/ComputeAverages.cpp
+++ b/src_common/ComputeAverages.cpp
@@ -294,7 +294,7 @@ void ComputeVerticalAverage(const MultiFab& mf, MultiFab& mf_flat,
 
         if (dir == 0) {
         
-            for (auto n = incomp; n<incomp+ncomp; ++n) {
+            for (auto n = 0; n<ncomp; ++n) {
             for (auto k = lo.z; k <= hi.z; ++k) {
             for (auto j = lo.y; j <= hi.y; ++j) {
             for (auto i = lo.x; i <= hi.x; ++i) {
@@ -308,7 +308,7 @@ void ComputeVerticalAverage(const MultiFab& mf, MultiFab& mf_flat,
             
         } else if (dir == 1) {
         
-            for (auto n = incomp; n<incomp+ncomp; ++n) {
+            for (auto n = 0; n<ncomp; ++n) {
             for (auto k = lo.z; k <= hi.z; ++k) {
             for (auto j = lo.y; j <= hi.y; ++j) {
             for (auto i = lo.x; i <= hi.x; ++i) {
@@ -322,7 +322,7 @@ void ComputeVerticalAverage(const MultiFab& mf, MultiFab& mf_flat,
 
         } else if (dir == 2) {
         
-            for (auto n = incomp; n<incomp+ncomp; ++n) {
+            for (auto n = 0; n<ncomp; ++n) {
             for (auto k = lo.z; k <= hi.z; ++k) {
             for (auto j = lo.y; j <= hi.y; ++j) {
             for (auto i = lo.x; i <= hi.x; ++i) {

--- a/src_common/ComputeAverages.cpp
+++ b/src_common/ComputeAverages.cpp
@@ -193,7 +193,7 @@ void WriteHorizontalAverageToMF(const MultiFab& mf_in, MultiFab& mf_out,
 
 
 void ComputeVerticalAverage(const MultiFab& mf, MultiFab& mf_flat,
-			    const Geometry& geom, const int& dir,
+			    const int& dir,
 			    const int& incomp, const int& ncomp,
                             const int& slablo, const int& slabhi)
 {
@@ -215,7 +215,7 @@ void ComputeVerticalAverage(const MultiFab& mf, MultiFab& mf_flat,
     MultiFab mf_pencil;
 
     // get a single Box that spans the full domain
-    Box domain(geom.Domain());
+    Box domain(mf.boxArray().minimalBox());
 
     // these are the transverse directions (i.e., NOT the dir direction)
     int dir1=0, dir2=0;
@@ -346,7 +346,7 @@ void ComputeVerticalAverage(const MultiFab& mf, MultiFab& mf_flat,
 }
 
 void ExtractSlice(const MultiFab& mf, MultiFab& mf_slice,
-                  const Geometry& geom, const int dir, const int slice,
+                  const int dir, const int slice,
                   const int incomp, const int ncomp)
 {
     BL_PROFILE_VAR("ExtractSlice()",ExtractSlice);
@@ -354,7 +354,7 @@ void ExtractSlice(const MultiFab& mf, MultiFab& mf_slice,
     // create BoxArray
 
     // get lo and hi coordinates of problem domain
-    Box domain(geom.Domain());
+    Box domain(mf.boxArray().minimalBox());
     IntVect dom_lo(domain.loVect());
     IntVect dom_hi(domain.hiVect());
 

--- a/src_common/ComputeAverages.cpp
+++ b/src_common/ComputeAverages.cpp
@@ -203,19 +203,31 @@ void ComputeVerticalAverage(const MultiFab& mf, MultiFab& mf_flat,
     if (dir >= AMREX_SPACEDIM) {
         Abort("ComputeVerticalAverage: invalid dir");
     }
-    
-    // debugging
-    bool write_data = false;
-
-    // this is a full MultiFab with pencil-shaped boxes
-    // we will define mf_flat as a flattened MultiFab that
-    // has the same BoxArray but flattened in the dir direction
-    // and the same DistributionMapping so
-    // we can do the averaging from mf_pencil to mf_flat on a box-by-box basis
-    MultiFab mf_pencil;
 
     // get a single Box that spans the full domain
     Box domain(mf.boxArray().minimalBox());
+
+    auto const& ma = mf.const_arrays();
+    auto fab = ReduceToPlane<ReduceOpSum,Real>(dir, domain, mf,
+      [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) -> Real
+      {
+          return ma[box_no](i,j,k); // data at (i,j,k) of Box box_no
+      });
+
+
+    Box dom2d = fab.box();
+    Vector<Box> bv(ParallelDescriptor::NProcs(),dom2d);
+    BoxArray ba(bv.data(), bv.size());
+
+    Vector<int> pmap(ParallelDescriptor::NProcs());
+    std::iota(pmap.begin(), pmap.end(), 0);
+    DistributionMapping dm(std::move(pmap));
+
+    MultiFab mftmp(ba, dm, fab.nComp(), 0, MFInfo().SetAlloc(false));
+    mftmp.setFab(ParallelDescriptor::MyProc(),
+                 FArrayBox(fab.box(), fab.nComp(), fab.dataPtr()));
+
+    BoxArray ba2(dom2d);
 
     // these are the transverse directions (i.e., NOT the dir direction)
     int dir1=0, dir2=0;
@@ -233,7 +245,7 @@ void ComputeVerticalAverage(const MultiFab& mf, MultiFab& mf_flat,
         dir2 = 1;
     }
 #endif
-
+    
     // max_grid_size_pencil will be equal to the number of cells in the domain in the dir direction
     // and uses max_grid_projection to set the non-dir directions
     Vector<int> max_grid_size_pencil(AMREX_SPACEDIM);
@@ -243,105 +255,11 @@ void ComputeVerticalAverage(const MultiFab& mf, MultiFab& mf_flat,
     max_grid_size_pencil[dir2] = max_grid_projection[1];
 #endif
 
-    // create the BoxArray for the pencil MultiFab
-    BoxArray ba_pencil(domain);
-    ba_pencil.maxSize(IntVect(max_grid_size_pencil));
+    ba2.maxSize(IntVect(max_grid_size_pencil));
 
-    // create DistributionMapping on the pencil BoxArray
-    DistributionMapping dmap_pencil(ba_pencil);
-
-    // build pencil MultiFab
-    mf_pencil.define(ba_pencil,dmap_pencil,ncomp,0);
-
-    // copy data from full MultiFab to pencil MultiFab
-    mf_pencil.ParallelCopy(mf, incomp, 0, ncomp);
-
-    // create a single flattened box with coordinate index 0 in the dir direction
-    IntVect dom_lo(domain.loVect());
-    IntVect dom_hi(domain.hiVect());
-    if (dom_lo[dir] != 0) {
-        Abort("ComputeVerticalAverage requires dom_lo[dir]=0");
-    }
-    dom_hi[dir] = 0;
-    Box domain_flat(dom_lo, dom_hi);
-    
-    // create the BoxArray for the flattened MultiFab
-    BoxArray ba_flat(domain_flat);
-    ba_flat.maxSize(IntVect(max_grid_size_pencil));
-
-    // build flattened MultiFab and initialize to zero
-    mf_flat.define(ba_flat,dmap_pencil,ncomp,0);
+    mf_flat.define(ba2, DistributionMapping{ba2}, fab.nComp(), 0);
     mf_flat.setVal(0.);
-
-    // this is the inverse of the number of cells in the dir direction we are averaging over
-    // by default we average over the entire domain, but one can pass in slab_lo/hi to set bounds
-    Real ninv;
-    if (slablo != -1 && slabhi != 99999) {
-        ninv = 1./(slabhi-slablo+1);
-    } else {
-        ninv = 1./(domain.length(dir));
-    }
-
-    // average pencil data onto the flattened MultiFab
-    for ( MFIter mfi(mf_pencil); mfi.isValid(); ++mfi ) {
-        const Box& bx = mfi.validbox();
-
-        const auto lo = amrex::lbound(bx);
-        const auto hi = amrex::ubound(bx);
-
-        const Array4<Real> meanfab = mf_flat.array(mfi);
-        const Array4<Real> inputfab = mf_pencil.array(mfi);
-
-        if (dir == 0) {
-        
-            for (auto n = 0; n<ncomp; ++n) {
-            for (auto k = lo.z; k <= hi.z; ++k) {
-            for (auto j = lo.y; j <= hi.y; ++j) {
-            for (auto i = lo.x; i <= hi.x; ++i) {
-                if ((i >= slablo) and (i <= slabhi)) {
-                    meanfab(0,j,k,n) = meanfab(0,j,k,n) + ninv*inputfab(i,j,k,n);
-                }
-            }
-            }
-            }
-            }
-            
-        } else if (dir == 1) {
-        
-            for (auto n = 0; n<ncomp; ++n) {
-            for (auto k = lo.z; k <= hi.z; ++k) {
-            for (auto j = lo.y; j <= hi.y; ++j) {
-            for (auto i = lo.x; i <= hi.x; ++i) {
-                if ((j >= slablo) and (j <= slabhi)) {
-                    meanfab(i,0,k,n) = meanfab(i,0,k,n) + ninv*inputfab(i,j,k,n);
-                }
-            }
-            }
-            }
-            }
-
-        } else if (dir == 2) {
-        
-            for (auto n = 0; n<ncomp; ++n) {
-            for (auto k = lo.z; k <= hi.z; ++k) {
-            for (auto j = lo.y; j <= hi.y; ++j) {
-            for (auto i = lo.x; i <= hi.x; ++i) {
-                if ((k >= slablo) and (k <= slabhi)) {
-                    meanfab(i,j,0,n) = meanfab(i,j,0,n) + ninv*inputfab(i,j,k,n);
-                }
-            }
-            }
-            }
-            }
-        }
-    }
-
-    // debugging
-    if (write_data) {
-        VisMF::Write(mf,"mf_full");
-        VisMF::Write(mf_pencil,"mf_pencil");
-        VisMF::Write(mf_flat,"mf_flat");
-    }
+    mf_flat.ParallelAdd(mftmp);
 
 }
 

--- a/src_common/common_functions.H
+++ b/src_common/common_functions.H
@@ -150,11 +150,11 @@ void WriteHorizontalAverageToMF(const MultiFab& mf_in, MultiFab& mf_out,
                                 const int& dir, const int& incomp,
                                 const int& ncomp, int outcomp=-1);
     
-void ComputeVerticalAverage(const MultiFab & mf, MultiFab & mf_flat, const Geometry & geom,
+void ComputeVerticalAverage(const MultiFab & mf, MultiFab & mf_flat,
                             const int& dir, const int& incomp, const int& ncomp,
                             const int& slablo=-1, const int& slabhi=99999);
 
-void ExtractSlice(const MultiFab & mf, MultiFab & mf_slice, const Geometry & geom,
+void ExtractSlice(const MultiFab & mf, MultiFab & mf_slice,
                   const int dir, const int slice, const int incomp, const int ncomp);
 
 ///////////////////////////

--- a/src_compressible/main_driver.cpp
+++ b/src_compressible/main_driver.cpp
@@ -476,9 +476,9 @@ void main_driver(const char* argv)
       // a built version of primFlattened so can obtain what we need to build the
       // structure factor and geometry objects for flattened data
       if (slicepoint < 0) {
-          ComputeVerticalAverage(structFactPrimMF, Flattened, geom, project_dir, 0, 1);
+          ComputeVerticalAverage(structFactPrimMF, Flattened, project_dir, 0, 1);
       } else {
-          ExtractSlice(structFactPrimMF, Flattened, geom, project_dir, slicepoint, 0, 1);
+          ExtractSlice(structFactPrimMF, Flattened, project_dir, slicepoint, 0, 1);
       }
       BoxArray ba_flat = Flattened.boxArray();
       const DistributionMapping& dmap_flat = Flattened.DistributionMap();
@@ -723,11 +723,11 @@ void main_driver(const char* argv)
                 MultiFab primFlattened;  // flattened multifab defined below
                 MultiFab consFlattened;  // flattened multifab defined below
                 if (slicepoint < 0) {
-                    ComputeVerticalAverage(structFactPrimMF, primFlattened, geom, project_dir, 0, structVarsPrim);
-                    ComputeVerticalAverage(structFactConsMF, consFlattened, geom, project_dir, 0, structVarsCons);
+                    ComputeVerticalAverage(structFactPrimMF, primFlattened, project_dir, 0, structVarsPrim);
+                    ComputeVerticalAverage(structFactConsMF, consFlattened, project_dir, 0, structVarsCons);
                 } else {
-                    ExtractSlice(structFactPrimMF, primFlattened, geom, project_dir, slicepoint, 0, structVarsPrim);
-                    ExtractSlice(structFactConsMF, consFlattened, geom, project_dir, slicepoint, 0, structVarsCons);
+                    ExtractSlice(structFactPrimMF, primFlattened, project_dir, slicepoint, 0, structVarsPrim);
+                    ExtractSlice(structFactConsMF, consFlattened, project_dir, slicepoint, 0, structVarsCons);
                 }
                 structFactPrimFlattened.FortStructure(primFlattened);
                 structFactConsFlattened.FortStructure(consFlattened);

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -774,7 +774,7 @@ void main_driver(const char* argv)
             // we are only calling ExtractSlice here to obtain
             // a built version of Flattened so can obtain what we need to build the
             // structure factor and geometry objects for flattened data
-            ExtractSlice(prim, Flattened, geom, project_dir, 0, 0, 1);
+            ExtractSlice(prim, Flattened, project_dir, 0, 0, 1);
 
             ba_flat = Flattened.boxArray();
             dmap_flat = Flattened.DistributionMap();
@@ -851,7 +851,7 @@ void main_driver(const char* argv)
                 surfcov_var_scaling[d] = 1.;
             }
       
-            ExtractSlice(surfcov, Flattened, geom, surfcov_dir, surfcov_plane, 0, surfcov_structVars);
+            ExtractSlice(surfcov, Flattened, surfcov_dir, surfcov_plane, 0, surfcov_structVars);
             BoxArray ba_surfcov = Flattened.boxArray();
             const DistributionMapping& dmap_surfcov = Flattened.DistributionMap();
             {
@@ -1330,14 +1330,14 @@ void main_driver(const char* argv)
                         {
                             MultiFab Flattened;
 
-                            ExtractSlice(structFactPrimMF, Flattened, geom, project_dir, i, 0, structVarsPrim);
+                            ExtractSlice(structFactPrimMF, Flattened, project_dir, i, 0, structVarsPrim);
                             structFactPrimArray[i].FortStructure(Flattened);
                         }
 
                         {
                             MultiFab Flattened;
 
-                            ExtractSlice(structFactConsMF, Flattened, geom, project_dir, i, 0, structVarsCons);
+                            ExtractSlice(structFactConsMF, Flattened, project_dir, i, 0, structVarsCons);
                             structFactConsArray[i].FortStructure(Flattened);
                         }
 
@@ -1350,9 +1350,9 @@ void main_driver(const char* argv)
                             MultiFab Flattened;
 
                             if (slicepoint < 0) {
-                                ComputeVerticalAverage(structFactPrimMF, Flattened, geom, project_dir, 0, structVarsPrim);
+                                ComputeVerticalAverage(structFactPrimMF, Flattened, project_dir, 0, structVarsPrim);
                             } else {
-                                ExtractSlice(structFactPrimMF, Flattened, geom, project_dir, slicepoint, 0, structVarsPrim);
+                                ExtractSlice(structFactPrimMF, Flattened, project_dir, slicepoint, 0, structVarsPrim);
                             }
                             structFactPrimFlattened.FortStructure(Flattened);
                         }
@@ -1361,9 +1361,9 @@ void main_driver(const char* argv)
                             MultiFab Flattened;
 
                             if (slicepoint < 0) {
-                                ComputeVerticalAverage(structFactConsMF, Flattened, geom, project_dir, 0, structVarsCons);
+                                ComputeVerticalAverage(structFactConsMF, Flattened, project_dir, 0, structVarsCons);
                             } else {
-                                ExtractSlice(structFactConsMF, Flattened, geom, project_dir, slicepoint, 0, structVarsCons);
+                                ExtractSlice(structFactConsMF, Flattened, project_dir, slicepoint, 0, structVarsCons);
                             }
                             structFactConsFlattened.FortStructure(Flattened);
                         }
@@ -1372,28 +1372,28 @@ void main_driver(const char* argv)
                         {
                             MultiFab Flattened;
 
-                            ComputeVerticalAverage(structFactPrimMF, Flattened, geom, project_dir, 0, structVarsPrim, 0, membrane_cell-1);
+                            ComputeVerticalAverage(structFactPrimMF, Flattened, project_dir, 0, structVarsPrim, 0, membrane_cell-1);
                             structFactPrimVerticalAverageMembraneLo.FortStructure(Flattened);
                         }
 
                         {
                             MultiFab Flattened;
 
-                            ComputeVerticalAverage(structFactPrimMF, Flattened, geom, project_dir, 0, structVarsPrim, membrane_cell, n_cells[project_dir]-1);
+                            ComputeVerticalAverage(structFactPrimMF, Flattened, project_dir, 0, structVarsPrim, membrane_cell, n_cells[project_dir]-1);
                             structFactPrimVerticalAverageMembraneHi.FortStructure(Flattened);
                         }
 
                         {
                             MultiFab Flattened;
 
-                            ComputeVerticalAverage(structFactConsMF, Flattened, geom, project_dir, 0, structVarsCons, 0, membrane_cell-1);
+                            ComputeVerticalAverage(structFactConsMF, Flattened, project_dir, 0, structVarsCons, 0, membrane_cell-1);
                             structFactConsVerticalAverageMembraneLo.FortStructure(Flattened);
                         }
 
                         {
                             MultiFab Flattened;
 
-                            ComputeVerticalAverage(structFactConsMF, Flattened, geom, project_dir, 0, structVarsCons, membrane_cell, n_cells[project_dir]-1);
+                            ComputeVerticalAverage(structFactConsMF, Flattened, project_dir, 0, structVarsCons, membrane_cell, n_cells[project_dir]-1);
                             structFactConsVerticalAverageMembraneHi.FortStructure(Flattened);
                         }
                     }
@@ -1405,7 +1405,7 @@ void main_driver(const char* argv)
                 int surfcov_plane = 0;
                 int surfcov_structVars = n_ads_spec;
                 MultiFab Flattened;  // flattened multifab defined below
-                ExtractSlice(surfcov, Flattened, geom, surfcov_dir, surfcov_plane, 0, surfcov_structVars);
+                ExtractSlice(surfcov, Flattened, surfcov_dir, surfcov_plane, 0, surfcov_structVars);
                 structFactSurfCov.FortStructure(Flattened);
             }
 

--- a/unmaintained/exercises/compressible/main_driver.cpp
+++ b/unmaintained/exercises/compressible/main_driver.cpp
@@ -412,7 +412,7 @@ void main_driver(const char* argv)
 
     if(project_dir >= 0){
       cu.setVal(0.0);
-      ComputeVerticalAverage(cu, cuVertAvg, geom, project_dir, 0, nvars);
+      ComputeVerticalAverage(cu, cuVertAvg, project_dir, 0, nvars);
       BoxArray ba_flat = cuVertAvg.boxArray();
       const DistributionMapping& dmap_flat = cuVertAvg.DistributionMap();
       {
@@ -538,7 +538,7 @@ void main_driver(const char* argv)
 //            MultiFab::Copy(struct_in_cc, cu, 0, 0, nvar_sf, 0);
 //            structFact.FortStructure(struct_in_cc);
 //            if(project_dir >= 0) {
-//                ComputeVerticalAverage(cu, cuVertAvg, geom, project_dir, 0, nvars);
+//                ComputeVerticalAverage(cu, cuVertAvg, project_dir, 0, nvars);
 //                structFactVA.FortStructure(cuVertAvg);
 //            }
 //        }


### PR DESCRIPTION
cleanup ExtractSlice and ComputeVerticalAverage routines
fix index bug for case where ComputeVerticalAverage is called with incomp>0
fixes the issue with running ComputeVerticalAverage on the GPU - you will no longer need to use amrex.the_arena_is_managed=1