### PR TITLE
Structure Factor Fixes

### DIFF
--- a/exec/DSMC/main_driver.cpp
+++ b/exec/DSMC/main_driver.cpp
@@ -415,7 +415,7 @@ void main_driver(const char* argv)
 			writePlotFile(cuInst,cuMeans,cuVars,primInst,primMeans,primVars,
 				coVars,spatialCross1D,particles,geom,time,ncross,istep);
 				
-			structFactPrim.WritePlotFile(istep,time,geom,"plt_SF_prim");
+			structFactPrim.WritePlotFile(istep,time,"plt_SF_prim");
 		}
 		
         if ((n_steps_skip > 0 && istep == n_steps_skip) || (n_steps_skip < 0 && istep%n_steps_skip == 0) ) {

--- a/exec/DSMC_granular/main_driver.cpp
+++ b/exec/DSMC_granular/main_driver.cpp
@@ -409,7 +409,7 @@ void main_driver(const char* argv)
 			struct_fact_int > 0 && plot_int > 0 &&
 			istep%plot_int == 0)
 		{
-			structFactPrim.WritePlotFile(istep,time,geom,"plt_SF_prim");
+			structFactPrim.WritePlotFile(istep,time,"plt_SF_prim");
 		}
 
 		//////////////////////////////////////

--- a/exec/cellbdytest_new/main_driver.cpp
+++ b/exec/cellbdytest_new/main_driver.cpp
@@ -1819,8 +1819,8 @@ void main_driver(const char* argv)
             
             // plot structure factor on plot_int
             if (istep%plot_int == 0) {
-                structFact_charge.WritePlotFile(istep,time,geomP,"plt_SF_charge");
-                structFact_vel   .WritePlotFile(istep,time,geom ,"plt_SF_vel");
+                structFact_charge.WritePlotFile(istep,time,"plt_SF_charge");
+                structFact_vel   .WritePlotFile(istep,time,"plt_SF_vel");
             }
         }
 

--- a/exec/hydro/main_driver.cpp
+++ b/exec/hydro/main_driver.cpp
@@ -351,8 +351,6 @@ void main_driver(const char* argv)
 
     StructFact structFactFlattened;
 
-    Geometry geom_sf_flat;
-
     if(project_dir >= 0){
       MultiFab Flattened;  // flattened multifab defined below
 
@@ -367,25 +365,6 @@ void main_driver(const char* argv)
 
       BoxArray ba_flat = Flattened.boxArray();
       const DistributionMapping& dmap_flat = Flattened.DistributionMap();
-
-      // create a Geometry object for SF plotfile so wavenumber appears in physical coordinates
-      Box domain_flat = ba_flat.minimalBox();
-
-      Vector<Real> projected_lo(AMREX_SPACEDIM);
-      Vector<Real> projected_hi(AMREX_SPACEDIM);
-
-      for (int d=0; d<AMREX_SPACEDIM; ++d) {
-          projected_lo[d] = -domain_flat.length(d)/2 - 0.5;
-          projected_hi[d] = domain_flat.length(d)/2 - 1 + 0.5;
-      }
-      projected_lo[project_dir] = -0.5;
-      projected_hi[project_dir] =  0.5;
-
-      RealBox real_box_flat({AMREX_D_DECL(projected_lo[0],projected_lo[1],projected_lo[2])},
-                            {AMREX_D_DECL(projected_hi[0],projected_hi[1],projected_hi[2])});
-
-      // This defines a Geometry object
-      geom_sf_flat.define(domain_flat,&real_box_flat,CoordSys::cartesian,is_periodic.data());
 
       structFactFlattened.define(ba_flat,dmap_flat,var_names,var_scaling);
     }
@@ -443,9 +422,9 @@ void main_driver(const char* argv)
         if (plot_int > 0) {
             WritePlotFile(0,time,geom,umac,pres);
             if (n_steps_skip == 0 && struct_fact_int > 0) {
-                structFact.WritePlotFile(0,0.,geom,"plt_SF");
+                structFact.WritePlotFile(0,0.,"plt_SF");
                 if(project_dir >= 0) {
-                    structFactFlattened.WritePlotFile(0,time,geom_sf_flat,"plt_SF_Flattened");
+                    structFactFlattened.WritePlotFile(0,time,"plt_SF_Flattened");
                 }
             }
         }
@@ -545,9 +524,9 @@ void main_driver(const char* argv)
 
             // write out structure factor to plotfile
             if (step > n_steps_skip && struct_fact_int > 0) {
-                structFact.WritePlotFile(step,time,geom,"plt_SF");
+                structFact.WritePlotFile(step,time,"plt_SF");
                 if(project_dir >= 0) {
-                    structFactFlattened.WritePlotFile(step,time,geom_sf_flat,"plt_SF_Flattened");
+                    structFactFlattened.WritePlotFile(step,time,"plt_SF_Flattened");
                 }
             }
 

--- a/exec/immersedIons/main_driver.cpp
+++ b/exec/immersedIons/main_driver.cpp
@@ -1589,8 +1589,8 @@ void main_driver(const char* argv)
             
             // plot structure factor on plot_int
             if (istep%plot_int == 0) {
-                structFact_charge.WritePlotFile(istep,time,geomP,"plt_SF_charge");
-                structFact_vel   .WritePlotFile(istep,time,geom ,"plt_SF_vel");
+                structFact_charge.WritePlotFile(istep,time,"plt_SF_charge");
+                structFact_vel   .WritePlotFile(istep,time,"plt_SF_vel");
             }
         }
 

--- a/exec/multispec/main_driver.cpp
+++ b/exec/multispec/main_driver.cpp
@@ -508,7 +508,7 @@ void main_driver(const char* argv)
         if (plot_int > 0) {
             WritePlotFile(0,0.,geom,umac,rhotot_old,rho_old,pi,charge_old,Epot);
             if (n_steps_skip == 0 && struct_fact_int > 0) {
-                structFact.WritePlotFile(0,0.,geom,"plt_SF");
+                structFact.WritePlotFile(0,0.,"plt_SF");
             }
         }
 
@@ -593,7 +593,7 @@ void main_driver(const char* argv)
         if (plot_int > 0 && istep%plot_int == 0) {
             WritePlotFile(istep,time,geom,umac,rhotot_new,rho_new,pi,charge_new,Epot);
             if (istep > n_steps_skip && struct_fact_int > 0) {
-                structFact.WritePlotFile(istep,time,geom,"plt_SF");
+                structFact.WritePlotFile(istep,time,"plt_SF");
             }
         }
 

--- a/exec/structFactTest/main_driver.cpp
+++ b/exec/structFactTest/main_driver.cpp
@@ -150,7 +150,7 @@ void main_driver(const char* argv)
     
     structFact.FortStructure(struct_cc);
       
-    structFact.WritePlotFile(0,0.,geom,"plt_SF");
+    structFact.WritePlotFile(0,0.,"plt_SF");
 
     // Call the timer again and compute the maximum difference between the start time
     // and stop time over all processors

--- a/src_MFsurfchem/MFsurfchem_functions.cpp
+++ b/src_MFsurfchem/MFsurfchem_functions.cpp
@@ -96,7 +96,7 @@ void init_surfcov(MultiFab& surfcov, const amrex::Geometry& geom)
 
         amrex::ParallelForRNG(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k, RandomEngine const& engine) noexcept
         {
-            if (k==0) {
+            if ( (project_dir == 0 && i == 0) || (project_dir == 1 && j == 0) || (project_dir == 2 && k == 0) ) {
                 if (stoch_surfcov0==1) {
                     amrex::Real Ntot = rint(surf_site_num_dens*dx[0]*dx[1]);  // total number of reactive sites
                     GpuArray<int,MAX_SPECIES> Nocc;
@@ -144,7 +144,7 @@ void sample_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab
 
         amrex::ParallelForRNG(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k, RandomEngine const& engine) noexcept
         {
-            if (k==0) {
+            if ( (project_dir == 0 && i == 0) || (project_dir == 1 && j == 0) || (project_dir == 2 && k == 0) ) {
                 amrex::Real sumtheta = 0.;
                 for (int m=0;m<n_ads_spec;m++) {
                     sumtheta += surfcov_arr(i,j,k,m);
@@ -198,7 +198,7 @@ void update_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab
         amrex::Real Ntot = surf_site_num_dens*dx[0]*dx[1];  // total number of reactive sites
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (k==0) {
+            if ( (project_dir == 0 && i == 0) || (project_dir == 1 && j == 0) || (project_dir == 2 && k == 0) ) {
 
                 amrex::Real T_inst = prim_arr(i,j,k,4);
 

--- a/src_analysis/StructFact.H
+++ b/src_analysis/StructFact.H
@@ -37,6 +37,8 @@ class StructFact {
     // Define vector of unique selected variables
     amrex::Vector< int > var_u;
 
+    Geometry geom_sf;
+
 public:
 
     // Vector containing running sums of real and imaginary components
@@ -86,8 +88,7 @@ public:
                     amrex::MultiFab&,
                     bool unpack=true);
 
-    void WritePlotFile(const int, const amrex::Real, const amrex::Geometry&, 
-                       std::string, const int& zero_avg=1);
+    void WritePlotFile(const int, const amrex::Real, std::string, const int& zero_avg=1);
     
     void Finalize(amrex::MultiFab&, amrex::MultiFab&,
                   const int& zero_avg=1);

--- a/src_compressible/main_driver.cpp
+++ b/src_compressible/main_driver.cpp
@@ -467,8 +467,6 @@ void main_driver(const char* argv)
 
     //////////////////////////////////////////////
     
-    Geometry geom_flat;
-    
     if(project_dir >= 0){
       MultiFab Flattened;  // flattened multifab defined below
       
@@ -482,28 +480,6 @@ void main_driver(const char* argv)
       }
       BoxArray ba_flat = Flattened.boxArray();
       const DistributionMapping& dmap_flat = Flattened.DistributionMap();
-      {
-          Box domain_flat = ba_flat.minimalBox();
-
-          // This defines the physical box
-          // we retain prob_lo and prob_hi in all directions except project_dir,
-          // where the physical size is 0 to dx[project_dir]
-          Vector<Real> projected_lo(AMREX_SPACEDIM);
-          Vector<Real> projected_hi(AMREX_SPACEDIM);
-
-          for (int d=0; d<AMREX_SPACEDIM; ++d) {
-              projected_lo[d] = prob_lo[d];
-              projected_hi[d] = prob_hi[d];
-          }
-          projected_lo[project_dir] = 0.;
-          projected_hi[project_dir] = (prob_hi[project_dir] - prob_lo[project_dir]) / n_cells[project_dir];
-
-          RealBox real_box_flat({AMREX_D_DECL(projected_lo[0],projected_lo[1],projected_lo[2])},
-                                {AMREX_D_DECL(projected_hi[0],projected_hi[1],projected_hi[2])});
-          
-          // This defines a Geometry object
-          geom_flat.define(domain_flat,&real_box_flat,CoordSys::cartesian,is_periodic.data());
-      }
 
       structFactPrimFlattened.define(ba_flat,dmap_flat,prim_var_names,var_scaling_prim);
       structFactConsFlattened.define(ba_flat,dmap_flat,cons_var_names,var_scaling_cons);
@@ -747,13 +723,13 @@ void main_driver(const char* argv)
 
 	    Print() << "HERE1\n";
 	    
-            structFactPrim.WritePlotFile(step,time,geom,"plt_SF_prim");
+            structFactPrim.WritePlotFile(step,time,"plt_SF_prim");
 
 	    Print() << "HERE2\n";
-            structFactCons.WritePlotFile(step,time,geom,"plt_SF_cons");
+            structFactCons.WritePlotFile(step,time,"plt_SF_cons");
             if(project_dir >= 0) {
-                structFactPrimFlattened.WritePlotFile(step,time,geom_flat,"plt_SF_prim_Flattened");
-                structFactConsFlattened.WritePlotFile(step,time,geom_flat,"plt_SF_cons_Flattened");
+                structFactPrimFlattened.WritePlotFile(step,time,"plt_SF_prim_Flattened");
+                structFactConsFlattened.WritePlotFile(step,time,"plt_SF_cons_Flattened");
             }
 
             // timer

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -802,7 +802,7 @@ void main_driver(const char* argv)
 
             if (do_2D) {
                 ///////////////////////////////////////////////////
-                // for SF plotfiles for use_2D case - needs to be cleaned up
+                // for SF plotfiles for do_2D case - needs to be cleaned up
                 // create a Geometry object for SF plotfile so wavenumber appears in physical coordinates
                 Box domain_flat = ba_flat.minimalBox();
 
@@ -1451,6 +1451,7 @@ void main_driver(const char* argv)
                 prim_realimag.setVal(0.0);
                 cons_realimag.setVal(0.0);
 
+                // note: above we force project_dir==2 for do_2D
                 for (int i=0; i<n_cells[2]; ++i) {
                     structFactPrimArray[i].AddToExternal(prim_mag,prim_realimag);
                     structFactConsArray[i].AddToExternal(cons_mag,cons_realimag);

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -779,26 +779,28 @@ void main_driver(const char* argv)
             ba_flat = Flattened.boxArray();
             dmap_flat = Flattened.DistributionMap();
 
-            ///////////////////////////////////////////////////
-            // for SF plotfiles for use_2D case - needs to be cleaned up
-            // create a Geometry object for SF plotfile so wavenumber appears in physical coordinates
-            Box domain_flat = ba_flat.minimalBox();
+            if (do_2D) {
+                ///////////////////////////////////////////////////
+                // for SF plotfiles for use_2D case - needs to be cleaned up
+                // create a Geometry object for SF plotfile so wavenumber appears in physical coordinates
+                Box domain_flat = ba_flat.minimalBox();
 
-            Vector<Real> projected_lo(AMREX_SPACEDIM);
-            Vector<Real> projected_hi(AMREX_SPACEDIM);
+                Vector<Real> projected_lo(AMREX_SPACEDIM);
+                Vector<Real> projected_hi(AMREX_SPACEDIM);
 
-            for (int d=0; d<AMREX_SPACEDIM; ++d) {
-            projected_lo[d] = -domain_flat.length(d)/2 - 0.5;
-            projected_hi[d] = domain_flat.length(d)/2 - 1 + 0.5;
-            }
-            projected_lo[project_dir] = -0.5;
-            projected_hi[project_dir] =  0.5;
+                for (int d=0; d<AMREX_SPACEDIM; ++d) {
+                    projected_lo[d] = -domain_flat.length(d)/2 - 0.5;
+                    projected_hi[d] = domain_flat.length(d)/2 - 1 + 0.5;
+                }
+                projected_lo[project_dir] = -0.5;
+                projected_hi[project_dir] =  0.5;
 
-            RealBox real_box_flat({AMREX_D_DECL(projected_lo[0],projected_lo[1],projected_lo[2])},
-                                  {AMREX_D_DECL(projected_hi[0],projected_hi[1],projected_hi[2])});
+                RealBox real_box_flat({AMREX_D_DECL(projected_lo[0],projected_lo[1],projected_lo[2])},
+                                      {AMREX_D_DECL(projected_hi[0],projected_hi[1],projected_hi[2])});
           
-            geom_sf_flat.define(domain_flat,&real_box_flat,CoordSys::cartesian,is_periodic.data());
-            ///////////////////////////////////////////////////
+                geom_sf_flat.define(domain_flat,&real_box_flat,CoordSys::cartesian,is_periodic.data());
+                ///////////////////////////////////////////////////
+            }
 
             if (do_2D) {
 

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -826,7 +826,7 @@ void main_driver(const char* argv)
             }
         }
 
-        if (n_ads_spec>0) {
+        if (n_ads_spec > 0 && (n_cells[0] != 1 || n_cells[1] != 1) ) {
 
             MultiFab Flattened;  // flattened multifab defined below
 
@@ -1379,8 +1379,8 @@ void main_driver(const char* argv)
                 }
                 
             }
-
-            if (n_ads_spec > 0) {
+            
+            if (n_ads_spec > 0 && (n_cells[0] != 1 || n_cells[1] != 1) ) {
                 int surfcov_dir = 2;
                 int surfcov_plane = 0;
                 int surfcov_structVars = n_ads_spec;
@@ -1446,7 +1446,7 @@ void main_driver(const char* argv)
 
             }
 
-            if (n_ads_spec > 0) {
+            if (n_ads_spec > 0 && (n_cells[0] != 1 || n_cells[1] != 1) ) {
                 structFactSurfCov.WritePlotFile(step,time,"plt_SF_surfcov");
             }
         }

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -961,8 +961,9 @@ void main_driver(const char* argv)
         amrex_push(cu, prim, *mpmd_copier);
 #endif
         if (n_ads_spec>0) {
-	    if (splitting_MFsurfchem == 0) sample_MFsurfchem(cu, prim, surfcov, dNadsdes, geom, dt);
-	    else if (splitting_MFsurfchem == 1) {
+	    if (splitting_MFsurfchem == 0) {
+                sample_MFsurfchem(cu, prim, surfcov, dNadsdes, geom, dt);
+            } else if (splitting_MFsurfchem == 1) {
 	        sample_MFsurfchem(cu, prim, surfcov, dNadsdes, geom, dt/2.0);
 		update_MFsurfchem(cu, prim, surfcov, dNadsdes, geom);
 
@@ -980,8 +981,9 @@ void main_driver(const char* argv)
                 cu.FillBoundary(geom.periodicity());
 
                 setBCStag(prim, cu, cumom, vel, geom);
-	    }
-	    else Abort("splitting_MFsurfchem can be 0 or 1");
+	    } else {
+                Abort("splitting_MFsurfchem can be 0 or 1");
+            }
 	}
 
         // FHD

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -312,7 +312,7 @@ void main_driver(const char* argv)
     Vector < StructFact > structFactPrimArray;
     Vector < StructFact > structFactConsArray;
     
-    Geometry geom_flat;
+    Geometry geom_sf_flat;
     BoxArray ba_flat;
     DistributionMapping dmap_flat;
 
@@ -320,7 +320,7 @@ void main_driver(const char* argv)
     // these are enabled if n_ads_spec > 0 and assumes the k=0 plane is the slice of interest
     StructFact structFactSurfCov;
     
-    Geometry geom_surfcov;
+    Geometry geom_sf_surfcov;
 
 #if defined(TURB)
     // Structure factor for compressible turbulence
@@ -781,26 +781,23 @@ void main_driver(const char* argv)
             ba_flat = Flattened.boxArray();
             dmap_flat = Flattened.DistributionMap();
 
+            // create a Geometry object for SF plotfile so wavenumber appears in physical coordinates
             Box domain_flat = ba_flat.minimalBox();
 
-            // This defines the physical box
-            // we retain prob_lo and prob_hi in all directions except project_dir,
-            // where the physical size is 0 to dx[project_dir]
             Vector<Real> projected_lo(AMREX_SPACEDIM);
             Vector<Real> projected_hi(AMREX_SPACEDIM);
 
             for (int d=0; d<AMREX_SPACEDIM; ++d) {
-                projected_lo[d] = prob_lo[d];
-                projected_hi[d] = prob_hi[d];
+            projected_lo[d] = -domain_flat.length(d)/2 - 0.5;
+            projected_hi[d] = domain_flat.length(d)/2 - 1 + 0.5;
             }
-            projected_lo[project_dir] = 0.;
-            projected_hi[project_dir] = dx[project_dir];
+            projected_lo[project_dir] = -0.5;
+            projected_hi[project_dir] =  0.5;
 
             RealBox real_box_flat({AMREX_D_DECL(projected_lo[0],projected_lo[1],projected_lo[2])},
                                   {AMREX_D_DECL(projected_hi[0],projected_hi[1],projected_hi[2])});
           
-            // This defines a Geometry object
-            geom_flat.define(domain_flat,&real_box_flat,CoordSys::cartesian,is_periodic.data());
+            geom_sf_flat.define(domain_flat,&real_box_flat,CoordSys::cartesian,is_periodic.data());
 
             if (do_2D) {
 
@@ -865,17 +862,17 @@ void main_driver(const char* argv)
                 Vector<Real> projected_hi(AMREX_SPACEDIM);
 
                 for (int d=0; d<AMREX_SPACEDIM; ++d) {
-                    projected_lo[d] = prob_lo[d];
-                    projected_hi[d] = prob_hi[d];
+                    projected_lo[d] = -domain_surfcov.length(d)/2 - 0.5;
+                    projected_hi[d] = domain_surfcov.length(d)/2 - 1 + 0.5;
                 }
-                projected_lo[surfcov_dir] = 0.;
-                projected_hi[surfcov_dir] = dx[surfcov_dir];
+                projected_lo[surfcov_dir] = -0.5;
+                projected_hi[surfcov_dir] = 0.5;
 
                 RealBox real_box_surfcov({AMREX_D_DECL(projected_lo[0],projected_lo[1],projected_lo[2])},
                                          {AMREX_D_DECL(projected_hi[0],projected_hi[1],projected_hi[2])});
         
                 // This defines a Geometry object
-                geom_surfcov.define(domain_surfcov,&real_box_surfcov,CoordSys::cartesian,is_periodic.data());
+                geom_sf_surfcov.define(domain_surfcov,&real_box_surfcov,CoordSys::cartesian,is_periodic.data());
             }
 
             structFactSurfCov.define(ba_surfcov,dmap_surfcov,surfcov_var_names,surfcov_var_scaling);
@@ -1425,14 +1422,14 @@ void main_driver(const char* argv)
 
             if (project_dir >= 0) {
                 if (do_slab_sf == 0) {
-                    structFactPrimFlattened.WritePlotFile(step,time,geom_flat,"plt_SF_prim_Flattened");
-                    structFactConsFlattened.WritePlotFile(step,time,geom_flat,"plt_SF_cons_Flattened");
+                    structFactPrimFlattened.WritePlotFile(step,time,geom_sf_flat,"plt_SF_prim_Flattened");
+                    structFactConsFlattened.WritePlotFile(step,time,geom_sf_flat,"plt_SF_cons_Flattened");
                 }
                 else {
-                    structFactPrimVerticalAverageMembraneLo.WritePlotFile(step,time,geom_flat,"plt_SF_prim_VerticalAverageMembraneLo");
-                    structFactPrimVerticalAverageMembraneHi.WritePlotFile(step,time,geom_flat,"plt_SF_prim_VerticalAverageMembraneHi");
-                    structFactConsVerticalAverageMembraneLo.WritePlotFile(step,time,geom_flat,"plt_SF_cons_VerticalAverageMembraneLo");
-                    structFactConsVerticalAverageMembraneHi.WritePlotFile(step,time,geom_flat,"plt_SF_cons_VerticalAverageMembraneHi");
+                    structFactPrimVerticalAverageMembraneLo.WritePlotFile(step,time,geom_sf_flat,"plt_SF_prim_VerticalAverageMembraneLo");
+                    structFactPrimVerticalAverageMembraneHi.WritePlotFile(step,time,geom_sf_flat,"plt_SF_prim_VerticalAverageMembraneHi");
+                    structFactConsVerticalAverageMembraneLo.WritePlotFile(step,time,geom_sf_flat,"plt_SF_cons_VerticalAverageMembraneLo");
+                    structFactConsVerticalAverageMembraneHi.WritePlotFile(step,time,geom_sf_flat,"plt_SF_cons_VerticalAverageMembraneHi");
                 }
             }
 
@@ -1461,15 +1458,15 @@ void main_driver(const char* argv)
                 prim_realimag.mult(ncellsinv);
                 cons_realimag.mult(ncellsinv);
 
-                WritePlotFilesSF_2D(prim_mag,prim_realimag,geom_flat,step,time,
+                WritePlotFilesSF_2D(prim_mag,prim_realimag,geom_sf_flat,step,time,
                                     structFactPrimArray[0].get_names(),"plt_SF_prim_2D");
-                WritePlotFilesSF_2D(cons_mag,cons_realimag,geom_flat,step,time,
+                WritePlotFilesSF_2D(cons_mag,cons_realimag,geom_sf_flat,step,time,
                                     structFactConsArray[0].get_names(),"plt_SF_cons_2D");
 
             }
 
             if (n_ads_spec > 0) {
-                structFactSurfCov.WritePlotFile(step,time,geom_surfcov,"plt_SF_surfcov");
+                structFactSurfCov.WritePlotFile(step,time,geom_sf_surfcov,"plt_SF_surfcov");
             }
         }
 

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -783,6 +783,9 @@ void main_driver(const char* argv)
         if ((do_1D==0) and (do_2D==0)) {
             structFactPrim.define(ba,dmap,prim_var_names,var_scaling_prim);
             structFactCons.define(ba,dmap,cons_var_names,var_scaling_cons);
+        }
+
+        if (do_1D==0) {
             structFactConsMF.define(ba,dmap,structVarsCons,0);
             structFactPrimMF.define(ba,dmap,structVarsPrim,0);
         }
@@ -1438,7 +1441,7 @@ void main_driver(const char* argv)
             }
 
             if (do_2D) {
-                    
+
                 MultiFab prim_mag, prim_realimag, cons_mag, cons_realimag;
 
                 prim_mag.define(ba_flat,dmap_flat,structFactPrimArray[0].get_ncov(),0);

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -780,14 +780,12 @@ void main_driver(const char* argv)
 
     if (struct_fact_int > 0) {
 
+        structFactConsMF.define(ba,dmap,structVarsCons,0);
+        structFactPrimMF.define(ba,dmap,structVarsPrim,0);
+
         if ((do_1D==0) and (do_2D==0)) {
             structFactPrim.define(ba,dmap,prim_var_names,var_scaling_prim);
             structFactCons.define(ba,dmap,cons_var_names,var_scaling_cons);
-        }
-
-        if (do_1D==0) {
-            structFactConsMF.define(ba,dmap,structVarsCons,0);
-            structFactPrimMF.define(ba,dmap,structVarsPrim,0);
         }
 
         // structure factor class for vertically-averaged dataset
@@ -836,17 +834,18 @@ void main_driver(const char* argv)
                     structFactConsArray[i].define(ba_flat,dmap_flat,cons_var_names,var_scaling_cons);
                 }
 
-            }
+            } else {
 
-            if (do_slab_sf == 0) {
-                structFactPrimFlattened.define(ba_flat,dmap_flat,prim_var_names,var_scaling_prim);
-                structFactConsFlattened.define(ba_flat,dmap_flat,cons_var_names,var_scaling_cons);
-            }
-            else {
-                structFactPrimVerticalAverageMembraneLo.define(ba_flat,dmap_flat,prim_var_names,var_scaling_prim);
-                structFactPrimVerticalAverageMembraneHi.define(ba_flat,dmap_flat,prim_var_names,var_scaling_prim);
-                structFactConsVerticalAverageMembraneLo.define(ba_flat,dmap_flat,cons_var_names,var_scaling_cons);
-                structFactConsVerticalAverageMembraneHi.define(ba_flat,dmap_flat,cons_var_names,var_scaling_cons);
+                if (do_slab_sf == 0) {
+                    structFactPrimFlattened.define(ba_flat,dmap_flat,prim_var_names,var_scaling_prim);
+                    structFactConsFlattened.define(ba_flat,dmap_flat,cons_var_names,var_scaling_cons);
+                }
+                else {
+                    structFactPrimVerticalAverageMembraneLo.define(ba_flat,dmap_flat,prim_var_names,var_scaling_prim);
+                    structFactPrimVerticalAverageMembraneHi.define(ba_flat,dmap_flat,prim_var_names,var_scaling_prim);
+                    structFactConsVerticalAverageMembraneLo.define(ba_flat,dmap_flat,cons_var_names,var_scaling_cons);
+                    structFactConsVerticalAverageMembraneHi.define(ba_flat,dmap_flat,cons_var_names,var_scaling_cons);
+                }
             }
         }
 
@@ -1347,64 +1346,64 @@ void main_driver(const char* argv)
                         }
 
                     }
-                }
-
-                if (do_slab_sf == 0) {
-                    
-                    {
-                        MultiFab Flattened;
-
-                        if (slicepoint < 0) {
-                            ComputeVerticalAverage(structFactPrimMF, Flattened, project_dir, 0, structVarsPrim);
-                        } else {
-                            ExtractSlice(structFactPrimMF, Flattened, project_dir, slicepoint, 0, structVarsPrim);
-                        }
-                        structFactPrimFlattened.FortStructure(Flattened);
-                    }
-
-                    {
-                        MultiFab Flattened;
-
-                        if (slicepoint < 0) {
-                            ComputeVerticalAverage(structFactConsMF, Flattened, project_dir, 0, structVarsCons);
-                        } else {
-                            ExtractSlice(structFactConsMF, Flattened, project_dir, slicepoint, 0, structVarsCons);
-                        }
-                        structFactConsFlattened.FortStructure(Flattened);
-                    }
-
                 } else {
+
+                    if (do_slab_sf == 0) {
                     
-                    {
-                        MultiFab Flattened;
+                        {
+                            MultiFab Flattened;
 
-                        ComputeVerticalAverage(structFactPrimMF, Flattened, project_dir, 0, structVarsPrim, 0, membrane_cell-1);
-                        structFactPrimVerticalAverageMembraneLo.FortStructure(Flattened);
-                    }
+                            if (slicepoint < 0) {
+                                ComputeVerticalAverage(structFactPrimMF, Flattened, project_dir, 0, structVarsPrim);
+                            } else {
+                                ExtractSlice(structFactPrimMF, Flattened, project_dir, slicepoint, 0, structVarsPrim);
+                            }
+                            structFactPrimFlattened.FortStructure(Flattened);
+                        }
 
-                    {
-                        MultiFab Flattened;
+                        {
+                            MultiFab Flattened;
 
-                        ComputeVerticalAverage(structFactPrimMF, Flattened, project_dir, 0, structVarsPrim, membrane_cell, n_cells[project_dir]-1);
-                        structFactPrimVerticalAverageMembraneHi.FortStructure(Flattened);
-                    }
+                            if (slicepoint < 0) {
+                                ComputeVerticalAverage(structFactConsMF, Flattened, project_dir, 0, structVarsCons);
+                            } else {
+                                ExtractSlice(structFactConsMF, Flattened, project_dir, slicepoint, 0, structVarsCons);
+                            }
+                            structFactConsFlattened.FortStructure(Flattened);
+                        }
 
-                    {
-                        MultiFab Flattened;
+                    } else {
+                    
+                        {
+                            MultiFab Flattened;
 
-                        ComputeVerticalAverage(structFactConsMF, Flattened, project_dir, 0, structVarsCons, 0, membrane_cell-1);
-                        structFactConsVerticalAverageMembraneLo.FortStructure(Flattened);
-                    }
+                            ComputeVerticalAverage(structFactPrimMF, Flattened, project_dir, 0, structVarsPrim, 0, membrane_cell-1);
+                            structFactPrimVerticalAverageMembraneLo.FortStructure(Flattened);
+                        }
 
-                    {
-                        MultiFab Flattened;
+                        {
+                            MultiFab Flattened;
 
-                        ComputeVerticalAverage(structFactConsMF, Flattened, project_dir, 0, structVarsCons, membrane_cell, n_cells[project_dir]-1);
-                        structFactConsVerticalAverageMembraneHi.FortStructure(Flattened);
-                    }
-                }
-                
-            }
+                            ComputeVerticalAverage(structFactPrimMF, Flattened, project_dir, 0, structVarsPrim, membrane_cell, n_cells[project_dir]-1);
+                            structFactPrimVerticalAverageMembraneHi.FortStructure(Flattened);
+                        }
+
+                        {
+                            MultiFab Flattened;
+
+                            ComputeVerticalAverage(structFactConsMF, Flattened, project_dir, 0, structVarsCons, 0, membrane_cell-1);
+                            structFactConsVerticalAverageMembraneLo.FortStructure(Flattened);
+                        }
+
+                        {
+                            MultiFab Flattened;
+
+                            ComputeVerticalAverage(structFactConsMF, Flattened, project_dir, 0, structVarsCons, membrane_cell, n_cells[project_dir]-1);
+                            structFactConsVerticalAverageMembraneHi.FortStructure(Flattened);
+                        }
+                    } // if (do_slab_sf...
+                } // if (do_2D...
+            } // if (project_dir >= 0)
 
             if (n_ads_spec > 0 && (n_cells[(project_dir+1)%3] != 1 || n_cells[(project_dir+2)%3] != 1) ) {
                 int surfcov_dir = project_dir;
@@ -1418,25 +1417,23 @@ void main_driver(const char* argv)
         }
 
         // write out structure factor
-        if (step > amrex::Math::abs(n_steps_skip) && 
-            struct_fact_int > 0 && plot_int > 0 && 
-            step%plot_int == 0) {
+        if (step > amrex::Math::abs(n_steps_skip) && struct_fact_int > 0 && plot_int > 0 && step%plot_int == 0) {
 
             if ((do_1D==0) and (do_2D==0)) {
                 structFactPrim.WritePlotFile(step,time,"plt_SF_prim");
                 structFactCons.WritePlotFile(step,time,"plt_SF_cons");
-            }
 
-            if (project_dir >= 0) {
-                if (do_slab_sf == 0) {
-                    structFactPrimFlattened.WritePlotFile(step,time,"plt_SF_prim_Flattened");
-                    structFactConsFlattened.WritePlotFile(step,time,"plt_SF_cons_Flattened");
-                }
-                else {
-                    structFactPrimVerticalAverageMembraneLo.WritePlotFile(step,time,"plt_SF_prim_VerticalAverageMembraneLo");
-                    structFactPrimVerticalAverageMembraneHi.WritePlotFile(step,time,"plt_SF_prim_VerticalAverageMembraneHi");
-                    structFactConsVerticalAverageMembraneLo.WritePlotFile(step,time,"plt_SF_cons_VerticalAverageMembraneLo");
-                    structFactConsVerticalAverageMembraneHi.WritePlotFile(step,time,"plt_SF_cons_VerticalAverageMembraneHi");
+                if (project_dir >= 0) {
+                    if (do_slab_sf == 0) {
+                        structFactPrimFlattened.WritePlotFile(step,time,"plt_SF_prim_Flattened");
+                        structFactConsFlattened.WritePlotFile(step,time,"plt_SF_cons_Flattened");
+                    }
+                    else {
+                        structFactPrimVerticalAverageMembraneLo.WritePlotFile(step,time,"plt_SF_prim_VerticalAverageMembraneLo");
+                        structFactPrimVerticalAverageMembraneHi.WritePlotFile(step,time,"plt_SF_prim_VerticalAverageMembraneHi");
+                        structFactConsVerticalAverageMembraneLo.WritePlotFile(step,time,"plt_SF_cons_VerticalAverageMembraneLo");
+                        structFactConsVerticalAverageMembraneHi.WritePlotFile(step,time,"plt_SF_cons_VerticalAverageMembraneHi");
+                    }
                 }
             }
 

--- a/src_reactDiff/main_driver.cpp
+++ b/src_reactDiff/main_driver.cpp
@@ -280,7 +280,7 @@ void main_driver(const char* argv)
 
             // write out structure factor to plotfile
             if (step > n_steps_skip && struct_fact_int > 0) {
-                structFact.WritePlotFile(step,time,geom,"plt_SF");
+                structFact.WritePlotFile(step,time,"plt_SF");
             }
         }
 


### PR DESCRIPTION
-Cleanup logic for when structure factors are permitted and computed based on do_1D, do_2D, project_dir, do_slab_sf.
  --This fixes the struct_fact_int>0 and (do_2D=1) case Changho reports.
-Prevent surfCov structure factor from being computed with nx=ny=1
  --This fixes the nx=ny=1 and meansurfchem=on case Changho reports.
-Structure factors now report k space index in the plotfile when you query the "physical" location.
  --The structure factor data itself is not modified; this only affects the "prob_lo" and "prob_hi" of the plotfile.  This is a cosmetic fix only as it allows users using amrVis to easily see kx,ky,kz for a given cell in a SF plotfile.
  Ffor uncoupled z-plane case (do_2D=1) the output structure factor is the average over each plane's individual structure factor.  There is no SF for vertically averaged data in that case, it makes no sense to do that.