### PR TITLE
Surface Chemistry fixes

### DIFF
--- a/src_MFsurfchem/MFsurfchem_namespace.H
+++ b/src_MFsurfchem/MFsurfchem_namespace.H
@@ -1,6 +1,7 @@
 namespace MFsurfchem {
 
     extern AMREX_GPU_MANAGED int n_ads_spec;
+    extern AMREX_GPU_MANAGED int ads_wall_dir;
 
     extern AMREX_GPU_MANAGED GpuArray<amrex::Real, MAX_SPECIES> surfcov0;
     extern AMREX_GPU_MANAGED amrex::Real surf_site_num_dens;


### PR DESCRIPTION
-Incorporate an ads_wall_dir for MFsurfchem surface direction
-Better error checking to make sure there is more than 1 cell in the surface or else skip the structure factors