### PR TITLE
MFsurfchem - modification of desorption species

### DIFF
--- a/src_MFsurfchem/MFsurfchem_functions.H
+++ b/src_MFsurfchem/MFsurfchem_functions.H
@@ -20,8 +20,8 @@ void InitializeMFSurfchemNamespace();
 
 void init_surfcov(MultiFab& surfcov, const amrex::Geometry& geom);
 
-void sample_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab& dNadsdes, const amrex::Geometry& geom, const amrex::Real dt);
+void sample_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab& dNadsdes, MultiFab& dNads, MultiFab& dNdes, const amrex::Geometry& geom, const amrex::Real dt);
 
-void update_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab& dNadsdes, const amrex::Geometry& geom);
+void update_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab& dNadsdes, MultiFab& dNads, MultiFab& dNdes, const amrex::Geometry& geom);
 
 #endif

--- a/src_MFsurfchem/MFsurfchem_namespace.H
+++ b/src_MFsurfchem/MFsurfchem_namespace.H
@@ -16,5 +16,6 @@ namespace MFsurfchem {
     extern AMREX_GPU_MANAGED amrex::Real e_beta;
 
     extern AMREX_GPU_MANAGED int splitting_MFsurfchem;
+    extern AMREX_GPU_MANAGED int conversion_MFsurfchem;
 
 }

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -214,6 +214,8 @@ void main_driver(const char* argv)
     // MFsurfchem
     MultiFab surfcov;       // also used in surfchem_mui for stats and plotfiles
     MultiFab dNadsdes;
+    MultiFab dNads;
+    MultiFab dNdes;
 
 #if defined(MUI) || defined(USE_AMREX_MPMD)
     MultiFab Ntot;          // saves total number of sites
@@ -536,6 +538,8 @@ void main_driver(const char* argv)
         
         if (n_ads_spec>0) {
             dNadsdes.define(ba,dmap,n_ads_spec,0);
+            dNads.define(ba,dmap,n_ads_spec,0);
+            dNdes.define(ba,dmap,n_ads_spec,0);
             nspec_surfcov = n_ads_spec;
         }
 
@@ -606,6 +610,8 @@ void main_driver(const char* argv)
         if (n_ads_spec>0) {
             surfcov.define(ba,dmap,n_ads_spec,0);
             dNadsdes.define(ba,dmap,n_ads_spec,0);
+            dNads.define(ba,dmap,n_ads_spec,0);
+            dNdes.define(ba,dmap,n_ads_spec,0);
             nspec_surfcov = n_ads_spec;
         }
 
@@ -997,10 +1003,10 @@ void main_driver(const char* argv)
 #endif
         if (n_ads_spec>0) {
 	    if (splitting_MFsurfchem == 0) {
-                sample_MFsurfchem(cu, prim, surfcov, dNadsdes, geom, dt);
+                sample_MFsurfchem(cu, prim, surfcov, dNadsdes, dNads, dNdes, geom, dt);
             } else if (splitting_MFsurfchem == 1) {
-	        sample_MFsurfchem(cu, prim, surfcov, dNadsdes, geom, dt/2.0);
-		update_MFsurfchem(cu, prim, surfcov, dNadsdes, geom);
+	        sample_MFsurfchem(cu, prim, surfcov, dNadsdes, dNads, dNdes, geom, dt/2.0);
+		update_MFsurfchem(cu, prim, surfcov, dNadsdes, dNads, dNdes, geom);
 
 		for (int d=0; d<AMREX_SPACEDIM; d++) {
 		    cumom[d].FillBoundary(geom.periodicity());
@@ -1031,7 +1037,7 @@ void main_driver(const char* argv)
 	  }
 
 	if (n_ads_spec>0 && splitting_MFsurfchem == 1) {
-            sample_MFsurfchem(cu, prim, surfcov, dNadsdes, geom, dt/2.0);
+            sample_MFsurfchem(cu, prim, surfcov, dNadsdes, dNads, dNdes, geom, dt/2.0);
         }
 
         // update surface chemistry (via either surfchem_mui or MFsurfchem)
@@ -1066,7 +1072,7 @@ void main_driver(const char* argv)
 
         if (n_ads_spec>0) {
 
-            update_MFsurfchem(cu, prim, surfcov, dNadsdes, geom);
+            update_MFsurfchem(cu, prim, surfcov, dNadsdes, dNads, dNdes, geom);
 
             for (int d=0; d<AMREX_SPACEDIM; d++) {
                 cumom[d].FillBoundary(geom.periodicity());


### PR DESCRIPTION
PR to review the "conversion_MFsurfchem" - modify the species involved in the desorption species.

1. conversion_MFsurfchem (default = 0, adsorption and desorption of species 1)
adsorption of species 1 and desorption of species (1+conversion_MFsurfchem)

2. dNads, dNdes (src_compressible_stag/main_driver.cpp)
To compute the number of adsorption and desorption separately.
(dNadsdes is defined as the difference between number of adsorption and desorption processes.)