### PR TITLE
Support for ensemble of pencil structure factor multifabs for the surface chemistry in do_2D mode

### DIFF
--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -908,7 +908,7 @@ void main_driver(const char* argv)
                 structFactSurfCovPencil.resize(n_cells[2]);
 
                 for (int i = 0; i < n_cells[2];  ++i) { 
-                    structFactSurfCovPencil[i].define(ba_pencil,dmap_pencil,prim_var_names,var_scaling_prim);
+                    structFactSurfCovPencil[i].define(ba_pencil,dmap_pencil,surfcov_var_names,surfcov_var_scaling);
                 }
 
             } else {

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -821,6 +821,9 @@ void main_driver(const char* argv)
                 surfCov_has_multiple_cells = 0;
             }
         } else {
+            // for full 3D simulations if n_cells=1 in both of the non-ads_wall_dir directions
+            // the surface coverage is only a single cell
+            // so don't take structure factors
             if (n_cells[(ads_wall_dir+1)%3] == 1 && n_cells[(ads_wall_dir+2)%3] == 1) {
                 surfCov_has_multiple_cells = 0;
             }


### PR DESCRIPTION
Now when using surface chemistry and do_2D, the surface chemistry structure factor is no longer a plane, but the average of many pencils.

Note there is now the strict requirement when n_ads_spec>0 and do_2D=1 that 
-project_dir=2 (so each z plane is decoupled) and
-ads_wall_dir=1 (surface chemistry is the lo-y wall).

Thus, the surfaceCoverage structure factor is the average of many 1D x-pencils of surface coverage.