### PR TITLE
Small fixes - main_driver.cpp and MFsurfchem

### DIFF
--- a/exec/compressible_stag_mui/GNUmakefile
+++ b/exec/compressible_stag_mui/GNUmakefile
@@ -3,21 +3,24 @@
 AMREX_HOME ?= ../../../amrex/
 MUI_HOME ?= ../../src_mui/
 
-BL_NO_FORT    = TRUE
 DEBUG         = FALSE
 USE_MPI       = TRUE
 USE_OMP       = FALSE
 USE_CUDA      = FALSE
+USE_HIP       = FALSE
 COMP          = gnu
 DIM           = 3
 TINY_PROFILE  = FALSE
-USE_MUI       = TRUE
-USE_SLURM     = FALSE
-USE_AMREX_MPMD = TRUE
 MAX_SPEC      = 8
 MAX_REAC      = 5
+USE_FFT       = TRUE
 
 USE_PARTICLES = FALSE
+DO_TURB       = FALSE
+
+USE_MUI       = FALSE
+USE_SLURM     = FALSE
+USE_AMREX_MPMD = TRUE
 
 ifeq ($(MAKECMDGOALS),spk)
   EBASE = spk
@@ -101,16 +104,16 @@ $(srcTempDir)/main_spk.cpp: SPPARKS_MUI/main.cpp
 
 spk: $(executable)
 
-else
-  ifeq ($(findstring cgpu, $(HOST)), cgpu)
-    CXXFLAGS += $(FFTW)
-  endif
+endif
 
-  ifeq ($(USE_CUDA),TRUE)
-    LIBRARIES += -lcufft
-  else
-    LIBRARIES += -L$(FFTW_DIR) -lfftw3_mpi -lfftw3
+ifeq ($(USE_FFT),TRUE)
+  ifeq ($(USE_CUDA),FALSE)
+    LIBRARIES += -L$(FFTW_DIR) -lfftw3_mpi -lfftw3f -lfftw3
   endif
+endif
+
+ifeq ($(DO_TURB), TRUE)
+  DEFINES += -DTURB
 endif
 
 ifeq ($(USE_MUI), TRUE)

--- a/src_MFsurfchem/MFsurfchem_functions.cpp
+++ b/src_MFsurfchem/MFsurfchem_functions.cpp
@@ -110,7 +110,7 @@ void init_surfcov(MultiFab& surfcov, const amrex::Geometry& geom)
         {
             if ( (ads_wall_dir == 0 && i == 0) || (ads_wall_dir == 1 && j == 0) || (ads_wall_dir == 2 && k == 0) ) {
                 if (stoch_surfcov0==1) {
-                    amrex::Real Ntot = rint(surf_site_num_dens*dx[0]*dx[1]);  // total number of reactive sites
+                    amrex::Real Ntot = rint(surf_site_num_dens*dx[(ads_wall_dir+1)%3]*dx[(ads_wall_dir+2)%3]);  // total number of reactive sites
                     GpuArray<int,MAX_SPECIES> Nocc;
                
                     for (int m=0;m<n_ads_spec;m++) Nocc[m] = 0;
@@ -154,7 +154,7 @@ void sample_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab
         const Array4<Real> & dNads_arr = dNads.array(mfi);
         const Array4<Real> & dNdes_arr = dNdes.array(mfi);
 
-        amrex::Real Ntot = surf_site_num_dens*dx[0]*dx[1];  // total number of reactive sites
+        amrex::Real Ntot = surf_site_num_dens*dx[(ads_wall_dir+1)%3]*dx[(ads_wall_dir+2)%3];  // total number of reactive sites
 
         amrex::ParallelForRNG(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k, RandomEngine const& engine) noexcept
         {
@@ -217,7 +217,7 @@ void update_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab
         const Array4<Real> & dNads_arr = dNads.array(mfi);
         const Array4<Real> & dNdes_arr = dNdes.array(mfi);
 
-        amrex::Real Ntot = surf_site_num_dens*dx[0]*dx[1];  // total number of reactive sites
+        amrex::Real Ntot = surf_site_num_dens*dx[(ads_wall_dir+1)%3]*dx[(ads_wall_dir+2)%3];  // total number of reactive sites
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             if ( (ads_wall_dir == 0 && i == 0) || (ads_wall_dir == 1 && j == 0) || (ads_wall_dir == 2 && k == 0) ) {

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -135,7 +135,7 @@ void main_driver(const char* argv)
     if (n_cells[0] == 1 && n_cells[1] > 1 && n_cells[2] == 1) {
         Abort("Cannot run a 1D simulation in the y-direcion; use n_cells[0]>1");
     }
-    if (n_cells[0] > 1 && n_cells[1] == 1 && n_cells[2] == 1) {
+    if (n_cells[0] > 1 && n_cells[1] == 1 && n_cells[2] == 1 && do_1D == 0) {
         Abort("1D simulations in the x-direction requires do_1D=1");
     }
     //**********************************************************************


### PR DESCRIPTION
1. src_compressible_stag/main_driver.cpp
: At line 138, the error message appears even when do_1D = 1. I suggest adding "&& do_1D == 0".

2. src_MFsurfchem/MFsurfchem_functions.cpp
: Fix dx[#] in the calculation of Ntot, based on the surface direction (ads_wall_dir).
Note that there was no issue with the previous result because I used dx=dy=dz before.

3. exec/compressible_stag_mui/GNUmakefile
: Based on the change in exec/compressible_stag/GNUmakefile, I have fixed GNUmakefile in compressible_stag_mui. I believe there are no issues.