### PR TITLE
do_2d mode slice structure factor

### DIFF
--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -1372,11 +1372,15 @@ void main_driver(const char* argv)
             turboutfiledecomp << std::endl;
         }
 #endif
+
+        bool SF_snapshot_taken = false;
         
         // collect a snapshot for structure factor
         if (struct_fact_int > 0 &&
-            step > amrex::Math::abs(n_steps_skip) && 
-            (step-amrex::Math::abs(n_steps_skip))%struct_fact_int == 0) {
+            step > amrex::Math::abs(n_steps_skip) &&
+            step%struct_fact_int == 0) {
+
+            SF_snapshot_taken = true;
             
             /////////// First structFactPrimMF ////////////////
             cnt = 0;
@@ -1543,8 +1547,7 @@ void main_driver(const char* argv)
 
         // write out structure factor
         if (struct_fact_int > 0 &&
-            step >= amrex::Math::abs(n_steps_skip) &&
-            step >= struct_fact_int &&
+            SF_snapshot_taken &&
             plot_int > 0 &&
             step%plot_int == 0) {
 


### PR DESCRIPTION
When using do_2D, you can now specify slicepoint = (a number that is not -1) to take an average of the pencil structure factors in the y direction (since we force ads_wall_dir=1 for do_2d mode).

Example useage to obtain the average of all pencil structure factors adjacent to the surface at the low-y interface

n_ads_spec = 1
do_2D = 1
project_dir = 2 // required to be 2 if do_2D=1, or else will abort
ads_wall_dir = 1 // required to be 1 if do_2D=1 and n_ads_spec>0, or else will abort
slicepoint = 0 // get the average of all the structure pencil factors at j=0