### PR TITLE
1 ghost cell for computing transport coefficients

### DIFF
--- a/src_compressible/transCoeffs.cpp
+++ b/src_compressible/transCoeffs.cpp
@@ -14,12 +14,17 @@ void calculateTransportCoeffs(const MultiFab& prim_in,
     // thread shared and thread private arrays on GPUs
     // if the size is not known at compile time, alternate approaches are required
     // here we know the size at compile time
-    
+
+    amrex::IntVect ng_temp;
+    for (int d=0; d<AMREX_SPACEDIM; ++d) {
+        ng_temp[d] = (do_1D == 1) ? 1 : ngc[d];
+    }
+
     // Loop over boxes
     for ( MFIter mfi(prim_in); mfi.isValid(); ++mfi) {
 
         // grow the box by ngc
-        const Box& bx = amrex::grow(mfi.tilebox(), 1);
+        const Box& bx = amrex::grow(mfi.tilebox(), ng_temp);
 
         const Array4<const Real>& prim = prim_in.array(mfi);
 

--- a/src_compressible/transCoeffs.cpp
+++ b/src_compressible/transCoeffs.cpp
@@ -19,7 +19,7 @@ void calculateTransportCoeffs(const MultiFab& prim_in,
     for ( MFIter mfi(prim_in); mfi.isValid(); ++mfi) {
 
         // grow the box by ngc
-        const Box& bx = amrex::grow(mfi.tilebox(), ngc);
+        const Box& bx = amrex::grow(mfi.tilebox(), 1);
 
         const Array4<const Real>& prim = prim_in.array(mfi);
 


### PR DESCRIPTION
When computing cell-centered transport coefficients, include only 1 ghost cell.

-The second layer of ghost cells don't affect the solution

-This fixes the do_1D "X by 1 by 1" case for an actual 1D pencil - the second ghost cell is never filled with a FillBoundary.