### PR TITLE
Small fix in SF_surfcov_2D plot and mean_MFsurfchem

### DIFF
--- a/src_MFsurfchem/MFsurfchem_functions.cpp
+++ b/src_MFsurfchem/MFsurfchem_functions.cpp
@@ -186,8 +186,8 @@ void sample_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab
 
                     amrex::Real theta = surfcov_arr(i,j,k,m);
 
-		    amrex::Real meanNads;
-		    amrex::Real meanNdes;
+                    amrex::Real meanNads;
+                    amrex::Real meanNdes;
 
                     if (mean_MFsurfchem==0) {
                         meanNads = ads_rate_const[m]*pres*(1-sumtheta)*Ntot*dt*pow(tempratio,k_beta);

--- a/src_MFsurfchem/MFsurfchem_functions.cpp
+++ b/src_MFsurfchem/MFsurfchem_functions.cpp
@@ -189,14 +189,14 @@ void sample_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab
 		    amrex::Real meanNads;
 		    amrex::Real meanNdes;
 
-		    if (mean_MFsurfchem==0) {
+                    if (mean_MFsurfchem==0) {
                         meanNads = ads_rate_const[m]*pres*(1-sumtheta)*Ntot*dt*pow(tempratio,k_beta);
                         meanNdes = des_rate[m]*theta*Ntot*dt;
-		    }
-		    else {
+                    }
+                    else {
                         meanNads = ads_rate_const[m]*mean_pressure[m]*(1-sumtheta)*Ntot*dt; // tempratio = 1
                         meanNdes = des_rate[m]*theta*Ntot*dt;
-		    }
+                    }
 
                     amrex::Real Nads;
                     amrex::Real Ndes;

--- a/src_MFsurfchem/MFsurfchem_functions.cpp
+++ b/src_MFsurfchem/MFsurfchem_functions.cpp
@@ -95,9 +95,11 @@ void InitializeMFSurfchemNamespace()
     mean_MFsurfchem = 0; // default value
     pp.query("mean_MFsurfchem",mean_MFsurfchem);
     if (mean_MFsurfchem > 0) {
-	std::vector<amrex::Real> mean_pressure_tmp(MAX_SPECIES);
-	pp.queryarr("mean_pressure",mean_pressure_tmp,0,n_ads_spec); // mean partial pressure of adsorption species
-	for (int m=0;m<n_ads_spec;m++) mean_pressure[m] = mean_pressure_tmp[m];
+        std::vector<amrex::Real> mean_pressure_tmp(MAX_SPECIES);
+        pp.queryarr("mean_pressure",mean_pressure_tmp,0,n_ads_spec); // mean partial pressure of adsorption species
+        for (int m=0;m<n_ads_spec;m++) {
+            mean_pressure[m] = mean_pressure_tmp[m];
+        }
     }
     return;
 }
@@ -188,12 +190,12 @@ void sample_MFsurfchem(MultiFab& cu, MultiFab& prim, MultiFab& surfcov, MultiFab
 		    amrex::Real meanNdes;
 
 		    if (mean_MFsurfchem==0) {
-		        meanNads = ads_rate_const[m]*pres*(1-sumtheta)*Ntot*dt*pow(tempratio,k_beta);
-			meanNdes = des_rate[m]*theta*Ntot*dt;
+                        meanNads = ads_rate_const[m]*pres*(1-sumtheta)*Ntot*dt*pow(tempratio,k_beta);
+                        meanNdes = des_rate[m]*theta*Ntot*dt;
 		    }
 		    else {
-			meanNads = ads_rate_const[m]*mean_pressure[m]*(1-sumtheta)*Ntot*dt; // tempratio = 1
-			meanNdes = des_rate[m]*theta*Ntot*dt;
+                        meanNads = ads_rate_const[m]*mean_pressure[m]*(1-sumtheta)*Ntot*dt; // tempratio = 1
+                        meanNdes = des_rate[m]*theta*Ntot*dt;
 		    }
 
                     amrex::Real Nads;

--- a/src_MFsurfchem/MFsurfchem_functions.cpp
+++ b/src_MFsurfchem/MFsurfchem_functions.cpp
@@ -94,7 +94,7 @@ void InitializeMFSurfchemNamespace()
     // Use equilibrium (mean) values of pressure and temperature to calculate adsorption rate
     mean_MFsurfchem = 0; // default value
     pp.query("mean_MFsurfchem",mean_MFsurfchem);
-    if (mean_MFsurfchem) {
+    if (mean_MFsurfchem > 0) {
 	std::vector<amrex::Real> mean_pressure_tmp(MAX_SPECIES);
 	pp.queryarr("mean_pressure",mean_pressure_tmp,0,n_ads_spec); // mean partial pressure of adsorption species
 	for (int m=0;m<n_ads_spec;m++) mean_pressure[m] = mean_pressure_tmp[m];

--- a/src_MFsurfchem/MFsurfchem_namespace.H
+++ b/src_MFsurfchem/MFsurfchem_namespace.H
@@ -18,4 +18,7 @@ namespace MFsurfchem {
     extern AMREX_GPU_MANAGED int splitting_MFsurfchem;
     extern AMREX_GPU_MANAGED int conversion_MFsurfchem;
 
+    extern AMREX_GPU_MANAGED int mean_MFsurfchem;
+    extern AMREX_GPU_MANAGED GpuArray<amrex::Real, MAX_SPECIES> mean_pressure;
+
 }

--- a/src_compressible_stag/main_driver.cpp
+++ b/src_compressible_stag/main_driver.cpp
@@ -1652,7 +1652,7 @@ void main_driver(const char* argv)
             //
             // 
 
-            if (n_ads_spec > 0 && surfCov_has_multiple_cells) {
+            if (do_2D && n_ads_spec > 0 && surfCov_has_multiple_cells) {
 
                 MultiFab surfcov_mag, surfcov_realimag;
 


### PR DESCRIPTION
1. src_compressible_stag/main_driver.cpp
: There is an error when simulating 3D system with both SF calculation and n_ads_spec>0.
This error is resolved by adding "do_2D &&" at line 1655 (if condition for plt_SF_surfcov_2D).
I fixed it temporarily since (i) it works in my current systems, and (ii) the error only occurs when n_ads_spec>0.

2. src_MFsurfchem/MFsurfchem_functions.cpp and MFsurfchem_namespace.H
: add mean_MFsurfchem and mean_pressure[m], to compute adsorption and desorption rates with equilibrium values