### PR TITLE
src_deankow: test the face index, not the box bounds, at physical bou…

### DIFF
--- a/src_deankow/1d_stats/main.cpp
+++ b/src_deankow/1d_stats/main.cpp
@@ -274,10 +274,10 @@ void main_main ()
         BoxArray edge_ba = ba;
         edge_ba.surroundingNodes(dir);
         flux[dir].define(edge_ba, dm, Ncomp, 0);
+        flux[dir].setVal(0.0);
         stochFlux[dir].define(edge_ba, dm, Ncomp, 0);
     }
 
-    flux[1].setVal(0.);
     AMREX_D_TERM(stochFlux[0].setVal(0.0);,
                  stochFlux[1].setVal(0.0);,
                  stochFlux[2].setVal(0.0););

--- a/src_deankow/1d_stats/mykernel.H
+++ b/src_deankow/1d_stats/mykernel.H
@@ -144,31 +144,27 @@ void compute_flux_y (int i, int j, int k,
                      amrex::Array4<amrex::Real const> const& phi, amrex::Real dyinv,
                      int lo, int hi, int dom_lo, int dom_hi, int bc_lo, int bc_hi, int Ncomp)
 {
+    amrex::ignore_unused(lo, hi);
     int coeff_index = Ncomp-1;
-    if (lo == dom_lo &&
+    // Note: the test has to be on the face index j, not on the box bounds lo/hi,
+    // otherwise every face of a box that touches the domain boundary is treated
+    // as a boundary face.
+    if (j == dom_lo &&
         (bc_lo == BCType::foextrap ||
          bc_lo == BCType::ext_dir))
     {
-        if(j == lo)
-        {
-            fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv / 0.5;
-        }
-        else
-        {
-            fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv;
+        fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv / 0.5;
+        if(Ncomp == 2){
+            fluxy(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j-1,k,1)) * dyinv / 0.5;
         }
     }
-    else if (hi == dom_hi &&
+    else if (j == dom_hi+1 &&
              (bc_hi == BCType::foextrap ||
               bc_hi == BCType::ext_dir))
     {
-        if(j == hi+1)
-        {
-            fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv / 0.5;
-        }
-        else
-        {
-            fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv;
+        fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv / 0.5;
+        if(Ncomp == 2){
+            fluxy(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j-1,k,1)) * dyinv / 0.5;
         }
     }
     else
@@ -192,33 +188,29 @@ void compute_flux_z (int i, int j, int k,
                      amrex::Array4<amrex::Real> const& fluxz,
                      amrex::Array4<amrex::Real> const& stochfluxz,
                      amrex::Array4<amrex::Real const> const& phi, amrex::Real dzinv,
-                     int lo, int hi, int dom_lo, int dom_hi, int bc_lo, int bc_hi)
+                     int lo, int hi, int dom_lo, int dom_hi, int bc_lo, int bc_hi, int Ncomp)
 {
+    amrex::ignore_unused(lo, hi);
     int coeff_index = Ncomp-1;
-    if (lo == dom_lo &&
+    // Note: the test has to be on the face index k, not on the box bounds lo/hi,
+    // otherwise every face of a box that touches the domain boundary is treated
+    // as a boundary face.
+    if (k == dom_lo &&
         (bc_lo == BCType::foextrap ||
          bc_lo == BCType::ext_dir))
     {
-        if(k == lo)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
-    else if (hi == dom_hi &&
+    else if (k == dom_hi+1 &&
              (bc_hi == BCType::foextrap ||
               bc_hi == BCType::ext_dir))
     {
-        if(k == hi+1)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
     else

--- a/src_deankow/ensemble/mykernel.H
+++ b/src_deankow/ensemble/mykernel.H
@@ -401,31 +401,27 @@ void compute_flux_z (int i, int j, int k,
         amrex::Abort("External potential not coded in 3D scenario yet.\n");
     }
 
+    amrex::ignore_unused(lo, hi);
     int coeff_index = Ncomp-1;
-    if (lo == dom_lo &&
+    // Note: the test has to be on the face index k, not on the box bounds lo/hi,
+    // otherwise every face of a box that touches the domain boundary is treated
+    // as a boundary face.
+    if (k == dom_lo &&
         (bc_lo == amrex::BCType::foextrap ||
          bc_lo == amrex::BCType::ext_dir))
     {
-        if(k == lo)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
-    else if (hi == dom_hi &&
+    else if (k == dom_hi+1 &&
              (bc_hi == amrex::BCType::foextrap ||
               bc_hi == amrex::BCType::ext_dir))
     {
-        if(k == hi+1)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
     else

--- a/src_deankow/moving/AdvancePhiAtLevel.cpp
+++ b/src_deankow/moving/AdvancePhiAtLevel.cpp
@@ -19,6 +19,7 @@ AmrCoreAdv::AdvancePhiAtLevel (int lev, Real time, Real dt_lev, int /*iteration*
         stochFluxes[i].setVal(0.);
         ba.surroundingNodes(i);
         fluxes[i].define(ba, dmap[lev], num_flux*phi_new[lev].nComp(), 0);
+        fluxes[i].setVal(0.);
     }
 
     phi_old[lev].FillBoundary(Geom(lev).periodicity());

--- a/src_deankow/moving/mykernel.H
+++ b/src_deankow/moving/mykernel.H
@@ -1028,31 +1028,27 @@ void compute_flux_z (int i, int j, int k,
                      amrex::Array4<amrex::Real const> const& phi, amrex::Real dzinv,
                      int lo, int hi, int dom_lo, int dom_hi, int bc_lo, int bc_hi, int Ncomp)
 {
+    amrex::ignore_unused(lo, hi);
     int coeff_index = Ncomp-1;
-    if (lo == dom_lo &&
+    // Note: the test has to be on the face index k, not on the box bounds lo/hi,
+    // otherwise every face of a box that touches the domain boundary is treated
+    // as a boundary face.
+    if (k == dom_lo &&
         (bc_lo == amrex::BCType::foextrap ||
          bc_lo == amrex::BCType::ext_dir))
     {
-        if(k == lo)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
-    else if (hi == dom_hi &&
+    else if (k == dom_hi+1 &&
              (bc_hi == amrex::BCType::foextrap ||
               bc_hi == amrex::BCType::ext_dir))
     {
-        if(k == hi+1)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
     else

--- a/src_deankow/multilevel/AdvancePhiAtLevel.cpp
+++ b/src_deankow/multilevel/AdvancePhiAtLevel.cpp
@@ -15,6 +15,7 @@ AmrCoreAdv::AdvancePhiAtLevel (int lev, Real /*time*/, Real dt_lev, int /*iterat
         BoxArray ba = grids[lev];
         ba.surroundingNodes(i);
         fluxes[i].define(ba, dmap[lev], phi_new[lev].nComp(), 0);
+        fluxes[i].setVal(0.);
         stochFluxes[i].define(ba, dmap[lev], phi_new[lev].nComp(), 0);
         stochFluxes[i].setVal(0.);
     }

--- a/src_deankow/multilevel/mykernel.H
+++ b/src_deankow/multilevel/mykernel.H
@@ -386,31 +386,27 @@ void compute_flux_z (int i, int j, int k,
                      amrex::Array4<amrex::Real const> const& phi, amrex::Real dzinv,
                      int lo, int hi, int dom_lo, int dom_hi, int bc_lo, int bc_hi, int Ncomp)
 {
+    amrex::ignore_unused(lo, hi);
     int coeff_index = Ncomp-1;
-    if (lo == dom_lo &&
+    // Note: the test has to be on the face index k, not on the box bounds lo/hi,
+    // otherwise every face of a box that touches the domain boundary is treated
+    // as a boundary face.
+    if (k == dom_lo &&
         (bc_lo == amrex::BCType::foextrap ||
          bc_lo == amrex::BCType::ext_dir))
     {
-        if(k == lo)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
-    else if (hi == dom_hi &&
+    else if (k == dom_hi+1 &&
              (bc_hi == amrex::BCType::foextrap ||
               bc_hi == amrex::BCType::ext_dir))
     {
-        if(k == hi+1)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
     else

--- a/src_deankow/singlelevel/main.cpp
+++ b/src_deankow/singlelevel/main.cpp
@@ -222,6 +222,7 @@ void main_main ()
         BoxArray edge_ba = ba;
         edge_ba.surroundingNodes(dir);
         flux[dir].define(edge_ba, dm, Ncomp, 0);
+        flux[dir].setVal(0.0);
         stochFlux[dir].define(edge_ba, dm, Ncomp, 0);
     }
 

--- a/src_deankow/singlelevel/mykernel.H
+++ b/src_deankow/singlelevel/mykernel.H
@@ -79,31 +79,27 @@ void compute_flux_x (int i, int j, int k,
                      amrex::Array4<amrex::Real const> const& phi, amrex::Real dxinv,
                      int lo, int hi, int dom_lo, int dom_hi, int bc_lo, int bc_hi,int Ncomp)
 {
+    amrex::ignore_unused(lo, hi);
     int coeff_index = Ncomp-1;
-    if (lo == dom_lo &&
+    // Note: the test has to be on the face index i, not on the box bounds lo/hi,
+    // otherwise every face of a box that touches the domain boundary is treated
+    // as a boundary face.
+    if (i == dom_lo &&
         (bc_lo == BCType::foextrap ||
          bc_lo == BCType::ext_dir))
     {
-        if(i == lo)
-        {
-            fluxx(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i-1,j,k,0)) * dxinv / 0.5;
-        }
-        else
-        {
-            fluxx(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i-1,j,k,0)) * dxinv;
+        fluxx(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i-1,j,k,0)) * dxinv / 0.5;
+        if(Ncomp == 2){
+            fluxx(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i-1,j,k,1)) * dxinv / 0.5;
         }
     }
-    else if (hi == dom_hi &&
+    else if (i == dom_hi+1 &&
              (bc_hi == BCType::foextrap ||
               bc_hi == BCType::ext_dir))
     {
-        if(i == hi+1)
-        {
-            fluxx(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i-1,j,k,0)) * dxinv / 0.5;
-        }
-        else
-        {
-            fluxx(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i-1,j,k,0)) * dxinv;
+        fluxx(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i-1,j,k,0)) * dxinv / 0.5;
+        if(Ncomp == 2){
+            fluxx(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i-1,j,k,1)) * dxinv / 0.5;
         }
     }
     else
@@ -128,31 +124,27 @@ void compute_flux_y (int i, int j, int k,
                      amrex::Array4<amrex::Real const> const& phi, amrex::Real dyinv,
                      int lo, int hi, int dom_lo, int dom_hi, int bc_lo, int bc_hi, int Ncomp)
 {
+    amrex::ignore_unused(lo, hi);
     int coeff_index = Ncomp-1;
-    if (lo == dom_lo &&
+    // Note: the test has to be on the face index j, not on the box bounds lo/hi,
+    // otherwise every face of a box that touches the domain boundary is treated
+    // as a boundary face.
+    if (j == dom_lo &&
         (bc_lo == BCType::foextrap ||
          bc_lo == BCType::ext_dir))
     {
-        if(j == lo)
-        {
-            fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv / 0.5;
-        }
-        else
-        {
-            fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv;
+        fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv / 0.5;
+        if(Ncomp == 2){
+            fluxy(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j-1,k,1)) * dyinv / 0.5;
         }
     }
-    else if (hi == dom_hi &&
+    else if (j == dom_hi+1 &&
              (bc_hi == BCType::foextrap ||
               bc_hi == BCType::ext_dir))
     {
-        if(j == hi+1)
-        {
-            fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv / 0.5;
-        }
-        else
-        {
-            fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv;
+        fluxy(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j-1,k,0)) * dyinv / 0.5;
+        if(Ncomp == 2){
+            fluxy(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j-1,k,1)) * dyinv / 0.5;
         }
     }
     else
@@ -179,31 +171,27 @@ void compute_flux_z (int i, int j, int k,
                      amrex::Array4<amrex::Real const> const& phi, amrex::Real dzinv,
                      int lo, int hi, int dom_lo, int dom_hi, int bc_lo, int bc_hi, int Ncomp)
 {
+    amrex::ignore_unused(lo, hi);
     int coeff_index = Ncomp-1;
-    if (lo == dom_lo &&
+    // Note: the test has to be on the face index k, not on the box bounds lo/hi,
+    // otherwise every face of a box that touches the domain boundary is treated
+    // as a boundary face.
+    if (k == dom_lo &&
         (bc_lo == BCType::foextrap ||
          bc_lo == BCType::ext_dir))
     {
-        if(k == lo)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
-    else if (hi == dom_hi &&
+    else if (k == dom_hi+1 &&
              (bc_hi == BCType::foextrap ||
               bc_hi == BCType::ext_dir))
     {
-        if(k == hi+1)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
     else

--- a/src_deankow/surface/AdvancePhiAtLevel.cpp
+++ b/src_deankow/surface/AdvancePhiAtLevel.cpp
@@ -17,6 +17,7 @@ AmrCoreAdv::AdvancePhiAtLevel (int lev, Real /*time*/, Real dt_lev, int /*iterat
         stochFluxes[i].setVal(0.);
         ba.surroundingNodes(i);
         fluxes[i].define(ba, dmap[lev], num_flux*phi_new[lev].nComp(), 0);
+        fluxes[i].setVal(0.);
     }
 
     phi_old[lev].FillBoundary(Geom(lev).periodicity());

--- a/src_deankow/surface/mykernel.H
+++ b/src_deankow/surface/mykernel.H
@@ -1028,31 +1028,27 @@ void compute_flux_z (int i, int j, int k,
                      amrex::Array4<amrex::Real const> const& phi, amrex::Real dzinv,
                      int lo, int hi, int dom_lo, int dom_hi, int bc_lo, int bc_hi, int Ncomp)
 {
+    amrex::ignore_unused(lo, hi);
     int coeff_index = Ncomp-1;
-    if (lo == dom_lo &&
+    // Note: the test has to be on the face index k, not on the box bounds lo/hi,
+    // otherwise every face of a box that touches the domain boundary is treated
+    // as a boundary face.
+    if (k == dom_lo &&
         (bc_lo == amrex::BCType::foextrap ||
          bc_lo == amrex::BCType::ext_dir))
     {
-        if(k == lo)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
-    else if (hi == dom_hi &&
+    else if (k == dom_hi+1 &&
              (bc_hi == amrex::BCType::foextrap ||
               bc_hi == amrex::BCType::ext_dir))
     {
-        if(k == hi+1)
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
-        }
-        else
-        {
-            fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv;
+        fluxz(i,j,k,0) = 0.5*(phi(i,j,k,0)-phi(i,j,k-1,0)) * dzinv / 0.5;
+        if(Ncomp == 2){
+            fluxz(i,j,k,1) = 0.5*(phi(i,j,k,1)-phi(i,j,k-1,1)) * dzinv / 0.5;
         }
     }
     else


### PR DESCRIPTION
…ndaries

Fixes #214.

The compute_flux_* routines gated the physical-boundary branch on the box extents (lo/hi from lbound/ubound of mfi.validbox()) instead of on the index of the face being processed, so every face of a box that touches the domain boundary took the boundary branch.  Two consequences, both only visible with foextrap/ext_dir BCs (a fully periodic run always lands in the else branch):

  - the stochastic flux, which is only added in the else branch, was dropped for those faces -- on a single-grid run that removes the noise from the whole domain;
  - for Ncomp == 2 (alg_type != 0) the boundary branch never wrote flux(i,j,k,1), so update_phi consumed uninitialized data.

Compare against the face index instead (i == dom_lo / i == dom_hi+1, and likewise for j and k), which collapses the nested conditional, and write component 1 in the boundary branch as well.

Also zero the flux MultiFabs where they are allocated so that any component left unwritten is a reproducible zero rather than garbage; ensemble already did this.  1d_stats' compute_flux_z was additionally missing the Ncomp parameter its caller passes, so it could not have compiled in 3D.